### PR TITLE
fix: CC002 detects missing token propagation inside lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-06-04
+
+### Fixed
+
+- **CC002** (`TokenPropagationAnalyzer`) now detects missing token propagation inside **lambda
+  expressions**, not just methods and local functions — closing a false negative where the analyzer's
+  own documentation already promised lambda support. A `Task.Delay(…)`/custom async call inside an
+  async lambda that owns a `CancellationToken` parameter (or captures one from an enclosing scope) is
+  now flagged. Example now caught:
+  ```csharp
+  Func<CancellationToken, Task> handler = async (CancellationToken ct) =>
+  {
+      await Task.Delay(100); // CC002: should pass ct
+  };
+  ```
+
+### Changed
+
+- **Token-scope walk unified.** CC002 and CC009 previously each carried a near-identical private
+  "walk up to the nearest enclosing scope that declares a `CancellationToken`" routine; the
+  lambda-aware version is now a single shared `CancellationTokenHelpers.FindEnclosingCancellationTokenParameter`.
+  This removed the duplication and is what gives CC002 its lambda support. CC009's behavior is
+  unchanged (its 19 tests still pass).
+
 ## [1.4.1] - 2026-06-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       await Task.Delay(100); // CC002: should pass ct
   };
   ```
+  The lambda walk deliberately excludes **expression-tree lambdas** (`Expression<TDelegate>`, e.g. an
+  `IQueryable`/EF predicate): code there is data, not executed, so a token cannot be propagated into it
+  (and an expression tree may not contain such a call anyway, CS0853/CS0854).
 
 ### Changed
 

--- a/docs/ANALYZER_HEALTH.md
+++ b/docs/ANALYZER_HEALTH.md
@@ -31,7 +31,7 @@ Calibration notes:
 | Rule | Title | Category | Severity | Analyzer | False Positives | Fix Strategy | Tests | Docs/Samples | Importance | Priority | Notes |
 | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
 | CC001 | Public async method missing CancellationToken | Usage | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Public/protected async returning Task/ValueTask, excludes override/interface/extern signatures (v1.4.0), compilable fixer (using insertion, name-collision, `params`). Solid entry-point guard. |
-| CC002 | CancellationToken not propagated | Usage | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | **v1.4.2:** now walks lambdas in addition to local functions and the containing method, via the shared `CancellationTokenHelpers.FindEnclosingCancellationTokenParameter` (also used by CC009). Closes the lambda false negative its docs already promised; docs now match behaviour. |
+| CC002 | CancellationToken not propagated | Usage | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | **v1.4.2:** now walks lambdas in addition to local functions and the containing method, via the shared `CancellationTokenHelpers.FindEnclosingCancellationTokenParameter` (also used by CC009). Closes the lambda false negative its docs already promised; docs now match behaviour. Expression-tree lambdas (`Expression<TDelegate>`) are deliberately excluded — code there is non-executable data. |
 | CC003 | EF Core async call missing CancellationToken | Usage | Warning | 3 | 4 | 4 | 4 | 3 | 4 | Medium | Namespace-gated to `Microsoft.EntityFrameworkCore`, overload-checked. Resolves the containing method via `FirstAncestorOrSelf<MethodDeclarationSyntax>`, so a call inside a local function or lambda with its own token is missed (false negative) — inconsistent with CC002/CC009. No analyzer XML doc. |
 | CC004 | HttpClient async call missing CancellationToken | Usage | Warning | 3 | 4 | 4 | 4 | 3 | 4 | Medium | Type-gated to `System.Net.Http.HttpClient`, overload-checked. Same containing-method-only scope gap as CC003. No analyzer XML doc. |
 | CC005A | MediatR handler missing CancellationToken | Usage | Warning | 3 | 4 | 4 | 4 | 3 | 2 | Low | Gated to `MediatR.IRequestHandler.Handle`. Real MediatR's interface already mandates the token, so the rule mostly assists a non-compiling handler rather than catching a live omission — low product importance. Uses an inline token check instead of the shared helper. |
@@ -96,10 +96,12 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 
 ## Verification Baseline
 
-- `dotnet test CancelCop.sln` — 153 passed, 0 failed after the CC002 lambda-scope fix (150 after
-  v1.4.1 + 3 new CC002 lambda tests).
-- `dotnet test … --filter FullyQualifiedName~TokenPropagationAnalyzer` — 14 passed (11 prior + 3 new:
-  lambda-owns-token, lambda-captures-outer-token, lambda-already-propagates negative).
+- `dotnet test CancelCop.sln` — 154 passed, 0 failed after the CC002 lambda-scope fix (150 after
+  v1.4.1 + 4 new CC002 tests).
+- `dotnet test … --filter FullyQualifiedName~TokenPropagationAnalyzer` — 15 passed (11 prior + 4 new:
+  lambda-owns-token, lambda-captures-outer-token, lambda-already-propagates negative, and
+  lambda-inside-`Expression<>`-tree negative — the last guards against firing on non-executable
+  expression-tree code, surfaced during review).
 - `dotnet test … --filter FullyQualifiedName~LoopCancellation` — unchanged and green after CC009 was
   migrated to the shared scope walk (refactor, no behaviour change).
 - `dotnet test … --filter FullyQualifiedName~MinimalApi` — 18 passed after the v1.4.1 CC005C hardening

--- a/docs/ANALYZER_HEALTH.md
+++ b/docs/ANALYZER_HEALTH.md
@@ -1,6 +1,6 @@
 # Analyzer Health
 
-Reviewed: 2026-06-04 (post v1.4.0, during the v1.4.1 hardening loop)
+Reviewed: 2026-06-04 (refreshed through the v1.4.2 hardening loop)
 
 A deliberately harsh health audit for the nine implemented CancelCop rule IDs (CC001–CC006, CC009).
 Scores are 1–5, where `5` means reference-quality and hard to improve, `3` means usable but
@@ -31,7 +31,7 @@ Calibration notes:
 | Rule | Title | Category | Severity | Analyzer | False Positives | Fix Strategy | Tests | Docs/Samples | Importance | Priority | Notes |
 | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
 | CC001 | Public async method missing CancellationToken | Usage | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Public/protected async returning Task/ValueTask, excludes override/interface/extern signatures (v1.4.0), compilable fixer (using insertion, name-collision, `params`). Solid entry-point guard. |
-| CC002 | CancellationToken not propagated | Usage | Warning | 3 | 4 | 4 | 4 | 3 | 4 | **Medium** | Walks local functions + containing method, but **not lambdas** — yet the XML docs claim "checks … lambda expressions for token availability." Silent false negative + docs drift. CC009 already walks lambdas; CC002 should mirror it. |
+| CC002 | CancellationToken not propagated | Usage | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | **v1.4.2:** now walks lambdas in addition to local functions and the containing method, via the shared `CancellationTokenHelpers.FindEnclosingCancellationTokenParameter` (also used by CC009). Closes the lambda false negative its docs already promised; docs now match behaviour. |
 | CC003 | EF Core async call missing CancellationToken | Usage | Warning | 3 | 4 | 4 | 4 | 3 | 4 | Medium | Namespace-gated to `Microsoft.EntityFrameworkCore`, overload-checked. Resolves the containing method via `FirstAncestorOrSelf<MethodDeclarationSyntax>`, so a call inside a local function or lambda with its own token is missed (false negative) — inconsistent with CC002/CC009. No analyzer XML doc. |
 | CC004 | HttpClient async call missing CancellationToken | Usage | Warning | 3 | 4 | 4 | 4 | 3 | 4 | Medium | Type-gated to `System.Net.Http.HttpClient`, overload-checked. Same containing-method-only scope gap as CC003. No analyzer XML doc. |
 | CC005A | MediatR handler missing CancellationToken | Usage | Warning | 3 | 4 | 4 | 4 | 3 | 2 | Low | Gated to `MediatR.IRequestHandler.Handle`. Real MediatR's interface already mandates the token, so the rule mostly assists a non-compiling handler rather than catching a live omission — low product importance. Uses an inline token check instead of the shared helper. |
@@ -45,8 +45,8 @@ Calibration notes:
 | Priority | Rules | Work |
 | --- | --- | --- |
 | High | None | No rule has a correctness defect severe enough to block a release. |
-| Medium | CC002, CC003, CC004 | Scope-walking gaps: CC002 ignores lambdas (and its docs claim otherwise); CC003/CC004 ignore local functions and lambdas. All three are silent false negatives that CC009's scope walk already solves. |
-| Low | CC001, CC005A, CC005B, CC005C, CC006, CC009 | Currently acceptable or low-impact. Improve opportunistically. |
+| Medium | CC003, CC004 | Scope-walking gap: both ignore local functions and lambdas (`FirstAncestorOrSelf<MethodDeclarationSyntax>`), a silent false negative that the shared `FindEnclosingCancellationTokenParameter` (now used by CC002/CC009) solves. |
+| Low | CC001, CC002, CC005A, CC005B, CC005C, CC006, CC009 | Currently acceptable or low-impact. Improve opportunistically. |
 
 ## Prioritized Fix Backlog
 
@@ -56,19 +56,20 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 - _None._
 
 ### P1 — Next hardening loop
-- **CC002 lambda scope + docs drift.** `FindContainingCancellationTokenParameter` walks
-  `LocalFunctionStatementSyntax` and `MethodDeclarationSyntax` but not `LambdaExpressionSyntax`, so a
-  `Task.Delay(…)`/custom async call inside an async lambda that owns a `CancellationToken` parameter is
-  never flagged — even though the XML docs explicitly promise lambda support. Mirror CC009's walk and
-  add tests. _(Loop 2 target.)_
+- **CC003 / CC004 scope consistency.** Both resolve the containing scope with
+  `FirstAncestorOrSelf<MethodDeclarationSyntax>`, so an EF Core / HttpClient call inside a local function
+  or lambda with its own token is missed (false negative) — inconsistent with CC002/CC009. Adopt the
+  shared `CancellationTokenHelpers.FindEnclosingCancellationTokenParameter` (added in v1.4.2) so all four
+  rules share one scope walk. _(Loop 3 target.)_
 
 ### P2 — Opportunistic
-- **CC003 / CC004 scope consistency.** Replace `FirstAncestorOrSelf<MethodDeclarationSyntax>` with the
-  shared local-function/lambda-aware walk so EF Core / HttpClient calls inside local functions and
-  lambdas are covered. Extract the walk into `CancellationTokenHelpers` so CC002/CC003/CC004/CC009 share
-  one implementation.
 - **CC005C method-group handlers.** Minimal APIs accept method groups (`app.MapGet("/", Handler)`), not
   just lambdas. Analyse the referenced method's signature for a token parameter.
+
+### Resolved
+- ~~**CC002 lambda scope + docs drift** (v1.4.2).~~ CC002 now walks lambdas via the shared
+  `FindEnclosingCancellationTokenParameter`; the docs' lambda-support promise is now true and pinned by
+  three new tests.
 
 ### P3 — Directional
 - **CC005A product value.** Document that CC005A mainly assists a handler that does not yet satisfy the
@@ -84,8 +85,10 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 - Every analyzer calls `ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None)` and
   `EnableConcurrentExecution()` — correct and consistent.
 - Shared logic lives in `CancellationTokenHelpers` (`IsCancellationToken`, `IsAsyncReturnType`,
-  `HasOverloadWithCancellationToken`, `IsSignatureExternallyControlled`). CC005A is the one analyzer
-  still hand-rolling a token check; CC002/CC003/CC004/CC009 each hand-roll the containing-scope walk.
+  `HasOverloadWithCancellationToken`, `IsSignatureExternallyControlled`, and — as of v1.4.2 —
+  `FindEnclosingCancellationTokenParameter`, the scope walk now shared by CC002 and CC009). CC005A
+  still hand-rolls its token check; CC003/CC004 still use the shallower
+  `FirstAncestorOrSelf<MethodDeclarationSyntax>` walk (P1 backlog).
 - Diagnostic placement is good: CC001/CC005A/CC005B on the method identifier, CC002/CC003/CC004 on the
   invoked member name, CC006 on the offending parameter, CC009 on the loop keyword.
 - Release tracking (`AnalyzerReleases.Shipped.md` / `.Unshipped.md`) is wired as `AdditionalFiles` with
@@ -93,9 +96,12 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 
 ## Verification Baseline
 
-- `dotnet test CancelCop.sln` — 149 passed, 0 failed after the CC005C hardening (147 pre-v1.4.1
-  baseline + 2 new negative tests + 1 new positive endpoint-module test, net of the unchanged total).
-- `dotnet test … --filter FullyQualifiedName~MinimalApi` — 18 passed after the CC005C hardening
-  (15 prior + 2 negative tests for non-endpoint `MapGet` lookalikes + 1 positive test for the
-  `this IEndpointRouteBuilder` endpoint-module idiom).
+- `dotnet test CancelCop.sln` — 153 passed, 0 failed after the CC002 lambda-scope fix (150 after
+  v1.4.1 + 3 new CC002 lambda tests).
+- `dotnet test … --filter FullyQualifiedName~TokenPropagationAnalyzer` — 14 passed (11 prior + 3 new:
+  lambda-owns-token, lambda-captures-outer-token, lambda-already-propagates negative).
+- `dotnet test … --filter FullyQualifiedName~LoopCancellation` — unchanged and green after CC009 was
+  migrated to the shared scope walk (refactor, no behaviour change).
+- `dotnet test … --filter FullyQualifiedName~MinimalApi` — 18 passed after the v1.4.1 CC005C hardening
+  (15 prior + 2 negative `MapGet`-lookalike tests + 1 positive `this IEndpointRouteBuilder` test).
 - Local SDK: .NET 10.0.300; `global.json` pins `10.0.300`. Tests target `net10.0`.

--- a/src/CancelCop.Analyzer.Package/CancelCop.Analyzer.Package.csproj
+++ b/src/CancelCop.Analyzer.Package/CancelCop.Analyzer.Package.csproj
@@ -13,7 +13,7 @@
         <PackageId>CancelCop.Analyzer</PackageId>
         <!-- Fallback for local packs; the publish workflow overrides this with -p:Version from
              the release tag so the published package always matches the tag. -->
-        <Version>1.4.1</Version>
+        <Version>1.4.2</Version>
         <Authors>George Wall</Authors>
         <Description>A surgical Roslyn analyzer focused on CancellationToken best practices: propagation, parameter positioning, loop cancellation checks, and more. Includes automatic code fixes for public APIs, handlers, EF Core, HTTP calls, and Minimal APIs.</Description>
         <PackageTags>roslyn;analyzer;cancellationtoken;async;code-fix;loops;efcore;httpclient</PackageTags>

--- a/src/CancelCop.Analyzer/CancellationTokenHelpers.cs
+++ b/src/CancelCop.Analyzer/CancellationTokenHelpers.cs
@@ -163,6 +163,42 @@ internal static class CancellationTokenHelpers
     }
 
     /// <summary>
+    /// Returns true when <paramref name="node"/> is lexically inside a lambda that is converted to a
+    /// <c>System.Linq.Expressions.Expression&lt;T&gt;</c> expression tree. Code inside an expression
+    /// tree is data — e.g. translated to SQL by an <c>IQueryable</c> provider — not executed, so a
+    /// <c>CancellationToken</c> cannot be propagated into it (and an expression tree may not contain a
+    /// call that uses optional/extra arguments anyway, CS0853/CS0854). Such calls must not be flagged.
+    /// </summary>
+    public static bool IsWithinExpressionTree(SyntaxNode node, SemanticModel semanticModel)
+    {
+        for (var current = node.Parent; current != null; current = current.Parent)
+        {
+            if (current is LambdaExpressionSyntax lambda &&
+                IsExpressionTreeType(semanticModel.GetTypeInfo(lambda).ConvertedType))
+                return true;
+
+            // A method or local-function body is executable code and can never sit inside an
+            // expression tree, so reaching one means we have left any enclosing tree.
+            if (current is MethodDeclarationSyntax || current is LocalFunctionStatementSyntax)
+                break;
+        }
+
+        return false;
+    }
+
+    private static bool IsExpressionTreeType(ITypeSymbol? type)
+    {
+        for (var current = type; current != null; current = current.BaseType)
+        {
+            if (current.Name == "Expression" &&
+                current.ContainingNamespace?.ToDisplayString() == "System.Linq.Expressions")
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Checks if any overload of the method accepts a CancellationToken parameter.
     /// </summary>
     public static bool HasOverloadWithCancellationToken(IMethodSymbol methodSymbol)

--- a/src/CancelCop.Analyzer/CancellationTokenHelpers.cs
+++ b/src/CancelCop.Analyzer/CancellationTokenHelpers.cs
@@ -76,6 +76,51 @@ internal static class CancellationTokenHelpers
     }
 
     /// <summary>
+    /// Walks up from <paramref name="node"/> through the scopes that can declare a
+    /// <c>CancellationToken</c> parameter — local functions, lambdas, and the containing method —
+    /// and returns the nearest in-scope token parameter, or <c>null</c> if none is available.
+    /// </summary>
+    /// <remarks>
+    /// A local function or lambda that has no token of its own does not stop the search: an outer
+    /// scope's token is captured and remains usable from the inner body. Reaching the containing
+    /// method declaration ends the search, because its parameter list is the outermost local scope
+    /// (class members are not parameters).
+    /// </remarks>
+    public static IParameterSymbol? FindEnclosingCancellationTokenParameter(
+        SyntaxNode node,
+        SemanticModel semanticModel)
+    {
+        var current = node.Parent;
+        while (current != null)
+        {
+            // Local function first (innermost), then lambda, then the containing method.
+            if (current is LocalFunctionStatementSyntax localFunction)
+            {
+                var token = FindCancellationTokenParameter(
+                    semanticModel.GetDeclaredSymbol(localFunction) as IMethodSymbol);
+                if (token != null)
+                    return token;
+            }
+            else if (current is LambdaExpressionSyntax lambda)
+            {
+                var token = FindCancellationTokenParameter(
+                    semanticModel.GetSymbolInfo(lambda).Symbol as IMethodSymbol);
+                if (token != null)
+                    return token;
+            }
+            else if (current is MethodDeclarationSyntax method)
+            {
+                return FindCancellationTokenParameter(
+                    semanticModel.GetDeclaredSymbol(method) as IMethodSymbol);
+            }
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Returns true when the method's signature is dictated by another declaration the developer
     /// cannot freely change here — an <c>override</c>, an explicit or implicit interface
     /// implementation, or an <c>extern</c> method. Adding or reordering a parameter on such a

--- a/src/CancelCop.Analyzer/LoopCancellationAnalyzer.cs
+++ b/src/CancelCop.Analyzer/LoopCancellationAnalyzer.cs
@@ -130,8 +130,9 @@ public class LoopCancellationAnalyzer : DiagnosticAnalyzer
 
     private void AnalyzeLoop(SyntaxNodeAnalysisContext context, SyntaxNode loopNode, StatementSyntax loopBody, SyntaxToken loopKeyword)
     {
-        // Find the containing method or local function that has a CancellationToken parameter
-        var tokenParameter = FindContainingCancellationTokenParameter(loopNode, context.SemanticModel);
+        // Find the containing method, local function, or lambda that has a CancellationToken parameter
+        var tokenParameter = CancellationTokenHelpers.FindEnclosingCancellationTokenParameter(
+            loopNode, context.SemanticModel);
         if (tokenParameter == null)
             return;
 
@@ -143,43 +144,6 @@ public class LoopCancellationAnalyzer : DiagnosticAnalyzer
         var properties = ImmutableDictionary<string, string?>.Empty.Add(TokenNameProperty, tokenParameter.Name);
         var diagnostic = Diagnostic.Create(Rule, loopKeyword.GetLocation(), properties, tokenParameter.Name);
         context.ReportDiagnostic(diagnostic);
-    }
-
-    /// <summary>
-    /// Finds the CancellationToken parameter from the containing method or local function.
-    /// Walks up the syntax tree to find the nearest scope with a CancellationToken parameter.
-    /// </summary>
-    private static IParameterSymbol? FindContainingCancellationTokenParameter(SyntaxNode node, SemanticModel semanticModel)
-    {
-        var current = node.Parent;
-        while (current != null)
-        {
-            if (current is LocalFunctionStatementSyntax localFunction)
-            {
-                var localFunctionSymbol = semanticModel.GetDeclaredSymbol(localFunction) as IMethodSymbol;
-                var tokenParam = CancellationTokenHelpers.FindCancellationTokenParameter(localFunctionSymbol);
-                if (tokenParam != null)
-                    return tokenParam;
-                // Continue walking up to find outer scope's token if local function doesn't have one
-            }
-            else if (current is MethodDeclarationSyntax methodDeclaration)
-            {
-                var methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration) as IMethodSymbol;
-                return CancellationTokenHelpers.FindCancellationTokenParameter(methodSymbol);
-            }
-            else if (current is LambdaExpressionSyntax lambda)
-            {
-                var lambdaSymbol = semanticModel.GetSymbolInfo(lambda).Symbol as IMethodSymbol;
-                var tokenParam = CancellationTokenHelpers.FindCancellationTokenParameter(lambdaSymbol);
-                if (tokenParam != null)
-                    return tokenParam;
-                // Continue walking up to find outer scope's token if lambda doesn't have one
-            }
-
-            current = current.Parent;
-        }
-
-        return null;
     }
 
     /// <summary>

--- a/src/CancelCop.Analyzer/TokenPropagationAnalyzer.cs
+++ b/src/CancelCop.Analyzer/TokenPropagationAnalyzer.cs
@@ -99,6 +99,11 @@ public class TokenPropagationAnalyzer : DiagnosticAnalyzer
         if (tokenParameter == null)
             return;
 
+        // An invocation inside an expression tree (e.g. an EF/IQueryable predicate lambda) is data,
+        // not executable code: the token cannot be propagated into it and the fix would not compile.
+        if (CancellationTokenHelpers.IsWithinExpressionTree(invocation, context.SemanticModel))
+            return;
+
         // Check if there's an overload that accepts a CancellationToken
         if (!CancellationTokenHelpers.HasOverloadWithCancellationToken(methodSymbol))
             return;

--- a/src/CancelCop.Analyzer/TokenPropagationAnalyzer.cs
+++ b/src/CancelCop.Analyzer/TokenPropagationAnalyzer.cs
@@ -92,8 +92,10 @@ public class TokenPropagationAnalyzer : DiagnosticAnalyzer
         if (CancellationTokenHelpers.HasCancellationTokenArgument(invocation, context.SemanticModel))
             return;
 
-        // Try to find CancellationToken parameter from containing local function first, then containing method
-        var tokenParameter = FindContainingCancellationTokenParameter(invocation, context.SemanticModel);
+        // Find the nearest in-scope CancellationToken parameter — from a containing local function,
+        // lambda, or the containing method.
+        var tokenParameter = CancellationTokenHelpers.FindEnclosingCancellationTokenParameter(
+            invocation, context.SemanticModel);
         if (tokenParameter == null)
             return;
 
@@ -116,40 +118,5 @@ public class TokenPropagationAnalyzer : DiagnosticAnalyzer
             tokenParameter.Name);
 
         context.ReportDiagnostic(diagnostic);
-    }
-
-    /// <summary>
-    /// Finds a CancellationToken parameter from the nearest containing local function or method.
-    /// Checks local functions first (innermost to outermost), then the containing method.
-    /// </summary>
-    private static IParameterSymbol? FindContainingCancellationTokenParameter(
-        SyntaxNode node,
-        SemanticModel semanticModel)
-    {
-        // Walk up the syntax tree looking for local functions and methods
-        var current = node.Parent;
-        while (current != null)
-        {
-            // Check local function first
-            if (current is LocalFunctionStatementSyntax localFunction)
-            {
-                // GetDeclaredSymbol(LocalFunctionStatementSyntax) returns ISymbol on the 4.8.0
-                // compile-time floor, so narrow it explicitly.
-                var localFunctionSymbol = semanticModel.GetDeclaredSymbol(localFunction) as IMethodSymbol;
-                var tokenParam = CancellationTokenHelpers.FindCancellationTokenParameter(localFunctionSymbol);
-                if (tokenParam != null)
-                    return tokenParam;
-            }
-            // Check method declaration
-            else if (current is MethodDeclarationSyntax methodDeclaration)
-            {
-                var methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration);
-                return CancellationTokenHelpers.FindCancellationTokenParameter(methodSymbol);
-            }
-
-            current = current.Parent;
-        }
-
-        return null;
     }
 }

--- a/tests/CancelCop.Analyzer.Tests/TokenPropagationAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/TokenPropagationAnalyzerTests.cs
@@ -362,4 +362,29 @@ public class TestClass
 
         await VerifyCS.VerifyAnalyzerAsync(test);
     }
+
+    [Fact]
+    public async Task Lambda_InExpressionTree_ShouldNotReportDiagnostic()
+    {
+        // A call inside an Expression<> tree is data (e.g. an IQueryable predicate translated to SQL),
+        // not executable code, so the token cannot be propagated into it — CC002 must stay quiet even
+        // when the lambda declares its own CancellationToken parameter (the code fix would not compile).
+        var test = @"
+using System;
+using System.Linq.Expressions;
+using System.Threading;
+
+public class TestClass
+{
+    public void Configure()
+    {
+        Expression<Func<CancellationToken, bool>> predicate = ct => Helper();
+    }
+
+    private static bool Helper() => true;
+    private static bool Helper(CancellationToken ct) => true;
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
 }

--- a/tests/CancelCop.Analyzer.Tests/TokenPropagationAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/TokenPropagationAnalyzerTests.cs
@@ -281,4 +281,85 @@ public class TestClass
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
+
+    [Fact]
+    public async Task Lambda_WithToken_TaskDelayWithoutToken_ShouldReportDiagnostic()
+    {
+        // A token owned by the lambda itself must be propagated to inner async calls. The analyzer's
+        // docs have always promised lambda support; this pins it.
+        var test = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    public void Configure()
+    {
+        Func<CancellationToken, Task> handler = async (CancellationToken ct) =>
+        {
+            await Task.{|#0:Delay|}(100);
+        };
+    }
+}";
+
+        var expected = VerifyCS.Diagnostic("CC002")
+            .WithLocation(0)
+            .WithArguments("Delay", "ct");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Lambda_NoToken_ButOuterMethodHasToken_ShouldReportDiagnostic()
+    {
+        // The lambda has no token, but it captures the outer method's token, which is usable inside
+        // the lambda body — so the walk continues outward and reports with the captured token.
+        var test = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    public async Task ProcessAsync(CancellationToken cancellationToken)
+    {
+        Func<Task> handler = async () =>
+        {
+            await Task.{|#0:Delay|}(100);
+        };
+
+        await handler();
+    }
+}";
+
+        var expected = VerifyCS.Diagnostic("CC002")
+            .WithLocation(0)
+            .WithArguments("Delay", "cancellationToken");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Lambda_WithToken_TaskDelayWithToken_ShouldNotReportDiagnostic()
+    {
+        // No false positive when the lambda already propagates its token.
+        var test = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    public void Configure()
+    {
+        Func<CancellationToken, Task> handler = async (CancellationToken ct) =>
+        {
+            await Task.Delay(100, ct);
+        };
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
 }


### PR DESCRIPTION
## Summary

CC002 (`TokenPropagationAnalyzer`) walked **local functions and the containing method** but **not lambdas**, so a missing token propagation inside an async lambda was never reported — even though the analyzer's own XML docs promise *"Checks method bodies, local functions, and lambda expressions for token availability."* This closes that false negative and makes the docs true.

Now caught:
```csharp
Func<CancellationToken, Task> handler = async (CancellationToken ct) =>
{
    await Task.Delay(100); // CC002: should pass ct
};
```

## Approach — unify the scope walk

CC002 and CC009 each carried a near-identical private *"walk up to the nearest enclosing scope that declares a `CancellationToken`"* routine; only CC009's handled lambdas. Rather than copy the lambda branch into CC002, the lambda-aware walk is now a single shared `CancellationTokenHelpers.FindEnclosingCancellationTokenParameter`:

- **CC002** adopts it → gains lambda support (the fix).
- **CC009** adopts it → no behaviour change (its 19 loop tests still pass; it already walked lambdas).

Net result: the two analyzers shrink, the duplication is gone, and there's one place to reason about token scoping (CC003/CC004 are queued to adopt it next — see `docs/ANALYZER_HEALTH.md` P1).

## Tests

Three new CC002 lambda tests:
- lambda **owns** the token → reports;
- lambda **captures** the outer method's token → reports (walk continues outward);
- lambda **already propagates** its token → no diagnostic (no false positive).

Full suite: **153 passed, 0 failed** (150 after v1.4.1 + 3 new). Release build: 0 errors.

## Also

- `docs/ANALYZER_HEALTH.md` refreshed (CC002 → Low priority; CC003/CC004 promoted to P1).
- Package `<Version>` fallback bumped to `1.4.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)