### PR TITLE
fix: CC003/CC004 detect missing tokens inside local functions and lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Both rules also gained CC002's **expression-tree guard**: a matching call inside an
   `Expression<TDelegate>` lambda is data, not executable code, so it is never flagged (the token
   could not be propagated there, and the fix would not compile).
+- The shared scope walk (CC002/CC003/CC004/CC009) now stops at a **`static` lambda or static local
+  function** that has no token of its own: a static anonymous function cannot capture the enclosing
+  method's token (CS8820/CS8421), so suggesting it was a false positive whose code fix did not
+  compile. Surfaced during review of this release.
+- The shared scope walk now also recognises **anonymous methods** (`async delegate (CancellationToken ct)
+  { … }`), which declare parameters just like lambdas but were previously invisible — a silent false
+  negative for all four propagation rules.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.3] - 2026-06-09
+
+### Fixed
+
+- **CC003** (`EFCoreAnalyzer`) and **CC004** (`HttpClientAnalyzer`) now find the available
+  `CancellationToken` with the same scope walk as CC002/CC009: the nearest enclosing **local
+  function, lambda, or method** that declares (or captures) a token parameter. Previously both
+  rules only looked at the containing method declaration
+  (`FirstAncestorOrSelf<MethodDeclarationSyntax>`), so an EF Core or `HttpClient` call inside a
+  local function or lambda that owned its own token was silently missed. Examples now caught:
+  ```csharp
+  async Task<int> CountUsersAsync(CancellationToken ct)   // local function
+  {
+      return await query.CountAsync();                    // CC003: should pass ct
+  }
+
+  Func<CancellationToken, Task<string>> fetch = async ct =>
+      await httpClient.GetStringAsync(url);               // CC004: should pass ct
+  ```
+- Both rules also gained CC002's **expression-tree guard**: a matching call inside an
+  `Expression<TDelegate>` lambda is data, not executable code, so it is never flagged (the token
+  could not be propagated there, and the fix would not compile).
+
+### Changed
+
+- All four token-propagation rules (CC002, CC003, CC004, CC009) now share the single
+  `CancellationTokenHelpers.FindEnclosingCancellationTokenParameter` scope walk, closing the
+  P1 "scope consistency" item from `docs/ANALYZER_HEALTH.md`.
+
 ## [1.4.2] - 2026-06-04
 
 ### Fixed

--- a/docs/ANALYZER_HEALTH.md
+++ b/docs/ANALYZER_HEALTH.md
@@ -1,6 +1,6 @@
 # Analyzer Health
 
-Reviewed: 2026-06-04 (refreshed through the v1.4.2 hardening loop)
+Reviewed: 2026-06-09 (refreshed through the v1.4.3 hardening loop)
 
 A deliberately harsh health audit for the nine implemented CancelCop rule IDs (CC001–CC006, CC009).
 Scores are 1–5, where `5` means reference-quality and hard to improve, `3` means usable but
@@ -32,8 +32,8 @@ Calibration notes:
 | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
 | CC001 | Public async method missing CancellationToken | Usage | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Public/protected async returning Task/ValueTask, excludes override/interface/extern signatures (v1.4.0), compilable fixer (using insertion, name-collision, `params`). Solid entry-point guard. |
 | CC002 | CancellationToken not propagated | Usage | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | **v1.4.2:** now walks lambdas in addition to local functions and the containing method, via the shared `CancellationTokenHelpers.FindEnclosingCancellationTokenParameter` (also used by CC009). Closes the lambda false negative its docs already promised; docs now match behaviour. Expression-tree lambdas (`Expression<TDelegate>`) are deliberately excluded — code there is non-executable data. |
-| CC003 | EF Core async call missing CancellationToken | Usage | Warning | 3 | 4 | 4 | 4 | 3 | 4 | Medium | Namespace-gated to `Microsoft.EntityFrameworkCore`, overload-checked. Resolves the containing method via `FirstAncestorOrSelf<MethodDeclarationSyntax>`, so a call inside a local function or lambda with its own token is missed (false negative) — inconsistent with CC002/CC009. No analyzer XML doc. |
-| CC004 | HttpClient async call missing CancellationToken | Usage | Warning | 3 | 4 | 4 | 4 | 3 | 4 | Medium | Type-gated to `System.Net.Http.HttpClient`, overload-checked. Same containing-method-only scope gap as CC003. No analyzer XML doc. |
+| CC003 | EF Core async call missing CancellationToken | Usage | Warning | 4 | 4 | 4 | 4 | 3 | 4 | Low | **v1.4.3:** now uses the shared `FindEnclosingCancellationTokenParameter` scope walk (local functions, lambdas, containing method) plus CC002's expression-tree guard, closing the scope-gap false negative and aligning all four propagation rules on one walk. Namespace-gated to `Microsoft.EntityFrameworkCore`, overload-checked. No analyzer XML doc (P3). |
+| CC004 | HttpClient async call missing CancellationToken | Usage | Warning | 4 | 4 | 4 | 4 | 3 | 4 | Low | **v1.4.3:** same shared scope walk + expression-tree guard as CC003. Type-gated to `System.Net.Http.HttpClient`, overload-checked. No analyzer XML doc (P3). |
 | CC005A | MediatR handler missing CancellationToken | Usage | Warning | 3 | 4 | 4 | 4 | 3 | 2 | Low | Gated to `MediatR.IRequestHandler.Handle`. Real MediatR's interface already mandates the token, so the rule mostly assists a non-compiling handler rather than catching a live omission — low product importance. Uses an inline token check instead of the shared helper. |
 | CC005B | Controller action missing CancellationToken | Usage | Warning | 4 | 4 | 4 | 4 | 3 | 4 | Low | Heavily hardened in v1.4.0: public non-static, `ControllerBase`/`Controller` by namespace, inherited `[NonAction]`, MVC HTTP-method attribute by identity + subclass. Conservative and accurate. |
 | CC005C | Minimal API handler missing CancellationToken | Usage | Warning | 4 | 4 | 4 | 4 | 3 | 4 | Low | **v1.4.1:** now gated on the receiver implementing `Microsoft.AspNetCore.Routing.IEndpointRouteBuilder`, so an unrelated `MapGet`-named method no longer false-positives (closes the last name-only match in the CC005 family). Remaining false negatives (both pre-existing, low value): method-group handlers (`app.MapGet("/", Handler)`) and the unreduced static-call form (`EndpointRouteBuilderExtensions.MapGet(app, …)`) are not analysed. |
@@ -45,8 +45,8 @@ Calibration notes:
 | Priority | Rules | Work |
 | --- | --- | --- |
 | High | None | No rule has a correctness defect severe enough to block a release. |
-| Medium | CC003, CC004 | Scope-walking gap: both ignore local functions and lambdas (`FirstAncestorOrSelf<MethodDeclarationSyntax>`), a silent false negative that the shared `FindEnclosingCancellationTokenParameter` (now used by CC002/CC009) solves. |
-| Low | CC001, CC002, CC005A, CC005B, CC005C, CC006, CC009 | Currently acceptable or low-impact. Improve opportunistically. |
+| Medium | None | The CC003/CC004 scope-walk gap was closed in v1.4.3; no medium-priority rule remains. |
+| Low | CC001, CC002, CC003, CC004, CC005A, CC005B, CC005C, CC006, CC009 | Currently acceptable or low-impact. Improve opportunistically. |
 
 ## Prioritized Fix Backlog
 
@@ -56,17 +56,19 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 - _None._
 
 ### P1 — Next hardening loop
-- **CC003 / CC004 scope consistency.** Both resolve the containing scope with
-  `FirstAncestorOrSelf<MethodDeclarationSyntax>`, so an EF Core / HttpClient call inside a local function
-  or lambda with its own token is missed (false negative) — inconsistent with CC002/CC009. Adopt the
-  shared `CancellationTokenHelpers.FindEnclosingCancellationTokenParameter` (added in v1.4.2) so all four
-  rules share one scope walk. _(Loop 3 target.)_
+- **CC005C method-group handlers.** Minimal APIs accept method groups (`app.MapGet("/", Handler)`), not
+  just lambdas. Analyse the referenced method's signature for a token parameter. _(Promoted from P2 —
+  next-largest real false-negative class now that scope walking is unified; loop 4 target.)_
 
 ### P2 — Opportunistic
-- **CC005C method-group handlers.** Minimal APIs accept method groups (`app.MapGet("/", Handler)`), not
-  just lambdas. Analyse the referenced method's signature for a token parameter.
+- _None currently._
 
 ### Resolved
+- ~~**CC003 / CC004 scope consistency** (v1.4.3).~~ Both now use the shared
+  `FindEnclosingCancellationTokenParameter` walk (local functions, lambdas, containing method) and
+  CC002's expression-tree guard; pinned by 9 new tests (5 EF Core, 4 HttpClient), including an
+  expression-tree negative built on a no-optional-args EF-namespace stub (real EF Core signatures
+  cannot appear in an expression tree, CS0854).
 - ~~**CC002 lambda scope + docs drift** (v1.4.2).~~ CC002 now walks lambdas via the shared
   `FindEnclosingCancellationTokenParameter`; the docs' lambda-support promise is now true and pinned by
   three new tests.
@@ -85,10 +87,9 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 - Every analyzer calls `ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None)` and
   `EnableConcurrentExecution()` — correct and consistent.
 - Shared logic lives in `CancellationTokenHelpers` (`IsCancellationToken`, `IsAsyncReturnType`,
-  `HasOverloadWithCancellationToken`, `IsSignatureExternallyControlled`, and — as of v1.4.2 —
-  `FindEnclosingCancellationTokenParameter`, the scope walk now shared by CC002 and CC009). CC005A
-  still hand-rolls its token check; CC003/CC004 still use the shallower
-  `FirstAncestorOrSelf<MethodDeclarationSyntax>` walk (P1 backlog).
+  `HasOverloadWithCancellationToken`, `IsSignatureExternallyControlled`, and
+  `FindEnclosingCancellationTokenParameter` — the scope walk shared by CC002, CC003, CC004, and CC009
+  as of v1.4.3). CC005A still hand-rolls its token check (P3 backlog).
 - Diagnostic placement is good: CC001/CC005A/CC005B on the method identifier, CC002/CC003/CC004 on the
   invoked member name, CC006 on the offending parameter, CC009 on the loop keyword.
 - Release tracking (`AnalyzerReleases.Shipped.md` / `.Unshipped.md`) is wired as `AdditionalFiles` with
@@ -96,14 +97,13 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 
 ## Verification Baseline
 
-- `dotnet test CancelCop.sln` — 154 passed, 0 failed after the CC002 lambda-scope fix (150 after
-  v1.4.1 + 4 new CC002 tests).
-- `dotnet test … --filter FullyQualifiedName~TokenPropagationAnalyzer` — 15 passed (11 prior + 4 new:
-  lambda-owns-token, lambda-captures-outer-token, lambda-already-propagates negative, and
-  lambda-inside-`Expression<>`-tree negative — the last guards against firing on non-executable
-  expression-tree code, surfaced during review).
-- `dotnet test … --filter FullyQualifiedName~LoopCancellation` — unchanged and green after CC009 was
-  migrated to the shared scope walk (refactor, no behaviour change).
-- `dotnet test … --filter FullyQualifiedName~MinimalApi` — 18 passed after the v1.4.1 CC005C hardening
-  (15 prior + 2 negative `MapGet`-lookalike tests + 1 positive `this IEndpointRouteBuilder` test).
+- `dotnet test CancelCop.sln` — 163 passed, 0 failed after the CC003/CC004 scope-walk fix (154 after
+  v1.4.2 + 9 new tests).
+- `dotnet test … --filter "FullyQualifiedName~EFCore|FullyQualifiedName~HttpClient"` — 36 passed
+  (27 prior + 9 new: local-function-owns-token, lambda-owns-token, lambda-captures-outer-token for
+  each rule, plus lambda-no-token negatives and an EF expression-tree negative).
+- `dotnet test … --filter FullyQualifiedName~TokenPropagationAnalyzer` — 15 passed (unchanged).
 - Local SDK: .NET 10.0.300; `global.json` pins `10.0.300`. Tests target `net10.0`.
+- Note: the Roslyn-testing NuGet cache at `%TEMP%\test-packages` can become torn (missing nuspec /
+  half-deleted package dirs) and fail every test with packaging exceptions; deleting the whole
+  folder and re-running restores it.

--- a/docs/ANALYZER_HEALTH.md
+++ b/docs/ANALYZER_HEALTH.md
@@ -61,7 +61,16 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
   next-largest real false-negative class now that scope walking is unified; loop 4 target.)_
 
 ### P2 — Opportunistic
-- _None currently._
+- **Constructor / primary-constructor token parameters.** The shared scope walk only terminates at
+  `MethodDeclarationSyntax`; a `CancellationToken` declared on a constructor, accessor, or C# 12
+  primary constructor is never found, so CC002/CC003/CC004/CC009 stay silent there (false negative,
+  parity with pre-v1.4.3 behaviour).
+- **Named-argument code fixes.** The CC003/CC004 fixers append a positional token argument; on a call
+  using out-of-position named arguments (`PostAsync(content: body, requestUri: url)`) the fixed call
+  hits CS8323. Needs a named-argument-aware insertion (`cancellationToken: ct`).
+- **Extract the shared report pipeline.** CC002/CC003/CC004 now end in a verbatim ~35-line block
+  (token-argument check → scope walk → expression-tree guard → overload check → report). One helper
+  would prevent the three-way drift this loop just fixed from recurring.
 
 ### Resolved
 - ~~**CC003 / CC004 scope consistency** (v1.4.3).~~ Both now use the shared
@@ -69,6 +78,11 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
   CC002's expression-tree guard; pinned by 9 new tests (5 EF Core, 4 HttpClient), including an
   expression-tree negative built on a no-optional-args EF-namespace stub (real EF Core signatures
   cannot appear in an expression tree, CS0854).
+- ~~**Static anonymous functions in the shared walk** (v1.4.3, surfaced in review).~~ A tokenless
+  `static` lambda / static local function now stops the walk — the outer token is not capturable
+  (CS8820/CS8421), so reporting it was a false positive with a non-compiling fix. The walk also
+  matches `AnonymousFunctionExpressionSyntax`, so `delegate (CancellationToken ct) { … }` parameters
+  are now found (previously a silent false negative). Pinned by 5 new tests across CC002/CC003/CC004.
 - ~~**CC002 lambda scope + docs drift** (v1.4.2).~~ CC002 now walks lambdas via the shared
   `FindEnclosingCancellationTokenParameter`; the docs' lambda-support promise is now true and pinned by
   three new tests.
@@ -97,12 +111,13 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 
 ## Verification Baseline
 
-- `dotnet test CancelCop.sln` — 163 passed, 0 failed after the CC003/CC004 scope-walk fix (154 after
-  v1.4.2 + 9 new tests).
-- `dotnet test … --filter "FullyQualifiedName~EFCore|FullyQualifiedName~HttpClient"` — 36 passed
-  (27 prior + 9 new: local-function-owns-token, lambda-owns-token, lambda-captures-outer-token for
-  each rule, plus lambda-no-token negatives and an EF expression-tree negative).
-- `dotnet test … --filter FullyQualifiedName~TokenPropagationAnalyzer` — 15 passed (unchanged).
+- `dotnet test CancelCop.sln` — 168 passed, 0 failed after the CC003/CC004 scope-walk fix plus the
+  static/anonymous-function hardening (154 after v1.4.2 + 14 new tests).
+- `dotnet test … --filter "FullyQualifiedName~EFCore|FullyQualifiedName~HttpClient"` — 39 passed
+  (27 prior + 12 new: local-function/lambda/captured-token positives, no-token and static-function
+  negatives, anonymous-method positive, and an EF expression-tree negative).
+- `dotnet test … --filter FullyQualifiedName~TokenPropagationAnalyzer` — 17 passed (15 prior +
+  static-lambda negative + anonymous-method positive).
 - Local SDK: .NET 10.0.300; `global.json` pins `10.0.300`. Tests target `net10.0`.
 - Note: the Roslyn-testing NuGet cache at `%TEMP%\test-packages` can become torn (missing nuspec /
   half-deleted package dirs) and fail every test with packaging exceptions; deleting the whole

--- a/src/CancelCop.Analyzer.Package/CancelCop.Analyzer.Package.csproj
+++ b/src/CancelCop.Analyzer.Package/CancelCop.Analyzer.Package.csproj
@@ -13,7 +13,7 @@
         <PackageId>CancelCop.Analyzer</PackageId>
         <!-- Fallback for local packs; the publish workflow overrides this with -p:Version from
              the release tag so the published package always matches the tag. -->
-        <Version>1.4.2</Version>
+        <Version>1.4.3</Version>
         <Authors>George Wall</Authors>
         <Description>A surgical Roslyn analyzer focused on CancellationToken best practices: propagation, parameter positioning, loop cancellation checks, and more. Includes automatic code fixes for public APIs, handlers, EF Core, HTTP calls, and Minimal APIs.</Description>
         <PackageTags>roslyn;analyzer;cancellationtoken;async;code-fix;loops;efcore;httpclient</PackageTags>

--- a/src/CancelCop.Analyzer/CancellationTokenHelpers.cs
+++ b/src/CancelCop.Analyzer/CancellationTokenHelpers.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CancelCop.Analyzer;
@@ -81,10 +82,12 @@ internal static class CancellationTokenHelpers
     /// and returns the nearest in-scope token parameter, or <c>null</c> if none is available.
     /// </summary>
     /// <remarks>
-    /// A local function or lambda that has no token of its own does not stop the search: an outer
-    /// scope's token is captured and remains usable from the inner body. Reaching the containing
-    /// method declaration ends the search, because its parameter list is the outermost local scope
-    /// (class members are not parameters).
+    /// A local function or anonymous function that has no token of its own does not stop the
+    /// search: an outer scope's token is captured and remains usable from the inner body — unless
+    /// the inner function is <c>static</c>, which forbids capturing enclosing parameters
+    /// (CS8421/CS8820), so a tokenless static function ends the search with no token. Reaching the
+    /// containing method declaration also ends the search, because its parameter list is the
+    /// outermost local scope (class members are not parameters).
     /// </remarks>
     public static IParameterSymbol? FindEnclosingCancellationTokenParameter(
         SyntaxNode node,
@@ -93,20 +96,25 @@ internal static class CancellationTokenHelpers
         var current = node.Parent;
         while (current != null)
         {
-            // Local function first (innermost), then lambda, then the containing method.
+            // Local function first (innermost), then lambda / anonymous method, then the
+            // containing method.
             if (current is LocalFunctionStatementSyntax localFunction)
             {
                 var token = FindCancellationTokenParameter(
                     semanticModel.GetDeclaredSymbol(localFunction) as IMethodSymbol);
                 if (token != null)
                     return token;
+                if (localFunction.Modifiers.Any(SyntaxKind.StaticKeyword))
+                    return null;
             }
-            else if (current is LambdaExpressionSyntax lambda)
+            else if (current is AnonymousFunctionExpressionSyntax anonymousFunction)
             {
                 var token = FindCancellationTokenParameter(
-                    semanticModel.GetSymbolInfo(lambda).Symbol as IMethodSymbol);
+                    semanticModel.GetSymbolInfo(anonymousFunction).Symbol as IMethodSymbol);
                 if (token != null)
                     return token;
+                if (anonymousFunction.Modifiers.Any(SyntaxKind.StaticKeyword))
+                    return null;
             }
             else if (current is MethodDeclarationSyntax method)
             {

--- a/src/CancelCop.Analyzer/EFCoreAnalyzer.cs
+++ b/src/CancelCop.Analyzer/EFCoreAnalyzer.cs
@@ -67,18 +67,16 @@ public class EFCoreAnalyzer : DiagnosticAnalyzer
         if (CancellationTokenHelpers.HasCancellationTokenArgument(invocation, context.SemanticModel))
             return;
 
-        // Find the containing method
-        var containingMethod = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-        if (containingMethod == null)
-            return;
-
-        var containingMethodSymbol = context.SemanticModel.GetDeclaredSymbol(containingMethod);
-        if (containingMethodSymbol == null)
-            return;
-
-        // Check if the containing method has a CancellationToken parameter
-        var tokenParameter = CancellationTokenHelpers.FindCancellationTokenParameter(containingMethodSymbol);
+        // Find the nearest in-scope CancellationToken parameter — from a containing local function,
+        // lambda, or the containing method.
+        var tokenParameter = CancellationTokenHelpers.FindEnclosingCancellationTokenParameter(
+            invocation, context.SemanticModel);
         if (tokenParameter == null)
+            return;
+
+        // An invocation inside an expression tree (e.g. an IQueryable predicate lambda) is data,
+        // not executable code: the token cannot be propagated into it and the fix would not compile.
+        if (CancellationTokenHelpers.IsWithinExpressionTree(invocation, context.SemanticModel))
             return;
 
         // Check if there's an overload that accepts a CancellationToken

--- a/src/CancelCop.Analyzer/HttpClientAnalyzer.cs
+++ b/src/CancelCop.Analyzer/HttpClientAnalyzer.cs
@@ -65,18 +65,16 @@ public class HttpClientAnalyzer : DiagnosticAnalyzer
         if (CancellationTokenHelpers.HasCancellationTokenArgument(invocation, context.SemanticModel))
             return;
 
-        // Find the containing method
-        var containingMethod = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-        if (containingMethod == null)
-            return;
-
-        var containingMethodSymbol = context.SemanticModel.GetDeclaredSymbol(containingMethod);
-        if (containingMethodSymbol == null)
-            return;
-
-        // Check if the containing method has a CancellationToken parameter
-        var tokenParameter = CancellationTokenHelpers.FindCancellationTokenParameter(containingMethodSymbol);
+        // Find the nearest in-scope CancellationToken parameter — from a containing local function,
+        // lambda, or the containing method.
+        var tokenParameter = CancellationTokenHelpers.FindEnclosingCancellationTokenParameter(
+            invocation, context.SemanticModel);
         if (tokenParameter == null)
+            return;
+
+        // An invocation inside an expression tree is data, not executable code: the token cannot
+        // be propagated into it and the fix would not compile.
+        if (CancellationTokenHelpers.IsWithinExpressionTree(invocation, context.SemanticModel))
             return;
 
         // Check if there's an overload that accepts a CancellationToken

--- a/tests/CancelCop.Analyzer.Tests/EFCoreAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/EFCoreAnalyzerTests.cs
@@ -381,6 +381,33 @@ public class User { public int Id { get; set; } }";
     }
 
     [Fact]
+    public async Task EFCoreMethod_InStaticLocalFunction_OuterTokenNotCapturable_ShouldNotReportDiagnostic()
+    {
+        // A static local function cannot capture the enclosing method's token (CS8421), so
+        // suggesting it would be a false positive with a non-compiling fix.
+        var test = @"
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+public class TestClass
+{
+    public void Setup(CancellationToken cancellationToken)
+    {
+        static async Task<int> CountUsersAsync(IQueryable<User> query)
+        {
+            return await query.CountAsync();
+        }
+    }
+}
+
+public class User { public int Id { get; set; } }";
+
+        await CreateTest(test).RunAsync();
+    }
+
+    [Fact]
     public async Task EFCoreMethod_NoTokenParameter_ShouldNotReportDiagnostic()
     {
         var test = @"

--- a/tests/CancelCop.Analyzer.Tests/EFCoreAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/EFCoreAnalyzerTests.cs
@@ -227,6 +227,160 @@ public class TestClass
     }
 
     [Fact]
+    public async Task EFCoreMethod_InLocalFunctionWithOwnToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+public class TestClass
+{
+    public void Setup()
+    {
+        async Task<int> CountUsersAsync(CancellationToken ct)
+        {
+            IQueryable<User> query = null;
+            return await query.{|#0:CountAsync|}();
+        }
+    }
+}
+
+public class User { public int Id { get; set; } }";
+
+        var expected = new DiagnosticResult("CC003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("CountAsync", "ct");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
+    public async Task EFCoreMethod_InLambdaWithOwnToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+public class TestClass
+{
+    public void Setup()
+    {
+        Func<CancellationToken, Task<int>> count = async ct =>
+        {
+            IQueryable<User> query = null;
+            return await query.{|#0:CountAsync|}();
+        };
+    }
+}
+
+public class User { public int Id { get; set; } }";
+
+        var expected = new DiagnosticResult("CC003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("CountAsync", "ct");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
+    public async Task EFCoreMethod_InLambdaCapturingOuterToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+public class TestClass
+{
+    public void Setup(CancellationToken cancellationToken)
+    {
+        Func<Task<int>> count = async () =>
+        {
+            IQueryable<User> query = null;
+            return await query.{|#0:CountAsync|}();
+        };
+    }
+}
+
+public class User { public int Id { get; set; } }";
+
+        var expected = new DiagnosticResult("CC003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("CountAsync", "cancellationToken");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
+    public async Task EFCoreMethod_InsideExpressionTree_ShouldNotReportDiagnostic()
+    {
+        // Real EF Core async methods take an optional CancellationToken, which an expression tree
+        // may not call (CS0854) — so the stub overload below has no optional parameters, keeping
+        // the tree compilable while still resolving into the Microsoft.EntityFrameworkCore namespace.
+        var test = @"
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class StubQueryableExtensions
+    {
+        public static Task<int> CountAsync<T>(this IQueryable<T> source) => null;
+        public static Task<int> CountAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken) => null;
+    }
+}
+
+public class TestClass
+{
+    public void Setup(IQueryable<User> query, CancellationToken cancellationToken)
+    {
+        Expression<Func<Task<int>>> count = () => query.CountAsync();
+    }
+}
+
+public class User { public int Id { get; set; } }";
+
+        await CreateTest(test).RunAsync();
+    }
+
+    [Fact]
+    public async Task EFCoreMethod_InLambda_NoTokenAnywhere_ShouldNotReportDiagnostic()
+    {
+        var test = @"
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+public class TestClass
+{
+    public void Setup()
+    {
+        Func<Task<int>> count = async () =>
+        {
+            IQueryable<User> query = null;
+            return await query.CountAsync();
+        };
+    }
+}
+
+public class User { public int Id { get; set; } }";
+
+        await CreateTest(test).RunAsync();
+    }
+
+    [Fact]
     public async Task EFCoreMethod_NoTokenParameter_ShouldNotReportDiagnostic()
     {
         var test = @"

--- a/tests/CancelCop.Analyzer.Tests/HttpClientAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/HttpClientAnalyzerTests.cs
@@ -261,4 +261,108 @@ public class TestClass
 
         await CreateTest(test, expected).RunAsync();
     }
+
+    [Fact]
+    public async Task HttpClientMethod_InLocalFunctionWithOwnToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    private readonly HttpClient _httpClient = new HttpClient();
+
+    public void Setup()
+    {
+        async Task<string> FetchAsync(CancellationToken ct)
+        {
+            return await _httpClient.{|#0:GetStringAsync|}(""https://api.example.com"");
+        }
+    }
+}";
+
+        var expected = new DiagnosticResult("CC004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("GetStringAsync", "ct");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
+    public async Task HttpClientMethod_InLambdaWithOwnToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    private readonly HttpClient _httpClient = new HttpClient();
+
+    public void Setup()
+    {
+        Func<CancellationToken, Task<string>> fetch = async ct =>
+            await _httpClient.{|#0:GetStringAsync|}(""https://api.example.com"");
+    }
+}";
+
+        var expected = new DiagnosticResult("CC004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("GetStringAsync", "ct");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
+    public async Task HttpClientMethod_InLambdaCapturingOuterToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    private readonly HttpClient _httpClient = new HttpClient();
+
+    public void Setup(CancellationToken cancellationToken)
+    {
+        Func<Task<string>> fetch = async () =>
+            await _httpClient.{|#0:GetStringAsync|}(""https://api.example.com"");
+    }
+}";
+
+        var expected = new DiagnosticResult("CC004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("GetStringAsync", "cancellationToken");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
+    public async Task HttpClientMethod_InLambda_NoTokenAnywhere_ShouldNotReportDiagnostic()
+    {
+        var test = @"
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    private readonly HttpClient _httpClient = new HttpClient();
+
+    public void Setup()
+    {
+        Func<Task<string>> fetch = async () =>
+            await _httpClient.GetStringAsync(""https://api.example.com"");
+    }
+}";
+
+        await CreateTest(test).RunAsync();
+    }
 }

--- a/tests/CancelCop.Analyzer.Tests/HttpClientAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/HttpClientAnalyzerTests.cs
@@ -345,6 +345,60 @@ public class TestClass
     }
 
     [Fact]
+    public async Task HttpClientMethod_InStaticLambda_OuterTokenNotCapturable_ShouldNotReportDiagnostic()
+    {
+        // A static lambda cannot capture the enclosing method's token (CS8820), so suggesting it
+        // would be a false positive with a non-compiling fix.
+        var test = @"
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    private static readonly HttpClient _httpClient = new HttpClient();
+
+    public void Setup(CancellationToken cancellationToken)
+    {
+        Func<Task<string>> fetch = static async () =>
+            await _httpClient.GetStringAsync(""https://api.example.com"");
+    }
+}";
+
+        await CreateTest(test).RunAsync();
+    }
+
+    [Fact]
+    public async Task HttpClientMethod_InAnonymousMethodWithOwnToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    private readonly HttpClient _httpClient = new HttpClient();
+
+    public void Setup()
+    {
+        Func<CancellationToken, Task<string>> fetch = async delegate (CancellationToken ct)
+        {
+            return await _httpClient.{|#0:GetStringAsync|}(""https://api.example.com"");
+        };
+    }
+}";
+
+        var expected = new DiagnosticResult("CC004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("GetStringAsync", "ct");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
     public async Task HttpClientMethod_InLambda_NoTokenAnywhere_ShouldNotReportDiagnostic()
     {
         var test = @"

--- a/tests/CancelCop.Analyzer.Tests/TokenPropagationAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/TokenPropagationAnalyzerTests.cs
@@ -387,4 +387,54 @@ public class TestClass
 
         await VerifyCS.VerifyAnalyzerAsync(test);
     }
+
+    [Fact]
+    public async Task Call_InStaticLambda_OuterTokenNotCapturable_ShouldNotReportDiagnostic()
+    {
+        // A static lambda cannot capture the enclosing method's token (CS8820), so suggesting it
+        // would be a false positive with a non-compiling fix.
+        var test = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    public void Setup(CancellationToken cancellationToken)
+    {
+        Func<Task> work = static async () =>
+        {
+            await Task.Delay(100);
+        };
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Call_InAnonymousMethodWithOwnToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    public void Setup()
+    {
+        Func<CancellationToken, Task> work = async delegate (CancellationToken ct)
+        {
+            await Task.{|#0:Delay|}(100);
+        };
+    }
+}";
+
+        var expected = VerifyCS.Diagnostic("CC002")
+            .WithLocation(0)
+            .WithArguments("Delay", "ct");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
 }


### PR DESCRIPTION
## Summary

Loop 3 of the analyzer-health hardening loop — closes the P1 backlog item from `docs/ANALYZER_HEALTH.md`.

- **CC003 (`EFCoreAnalyzer`) / CC004 (`HttpClientAnalyzer`)** previously resolved the available `CancellationToken` with `FirstAncestorOrSelf<MethodDeclarationSyntax>`, so an EF Core / HttpClient call inside a **local function or lambda** that owned (or captured) a token was silently missed — a false negative inconsistent with CC002/CC009.
- Both rules now use the shared `CancellationTokenHelpers.FindEnclosingCancellationTokenParameter` scope walk, so all four propagation rules (CC002/CC003/CC004/CC009) share one walk.
- Both rules also gained CC002's **expression-tree guard** — a matching call inside `Expression<TDelegate>` is data, not executable code, and is never flagged.
- Health scorecard refreshed: CC003/CC004 Analyzer 3→4, priority Medium→Low; version bumped to 1.4.3.

## Tests

- 9 new tests (5 EF Core, 4 HttpClient): local-function-owns-token, lambda-owns-token, lambda-captures-outer-token, lambda-no-token negatives, and an EF expression-tree negative (built on a no-optional-args stub in the `Microsoft.EntityFrameworkCore` namespace, since real EF signatures cannot appear in expression trees — CS0854).
- Full suite: **163 passed, 0 failed** (154 prior + 9 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)