### PR TITLE
feat: CC005C detects method-group Minimal API handlers missing tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never be "fixed" by adding a token parameter to an unrelated enclosing lambda (e.g. a registration
   lambda wrapping the `MapGet` call).
 
+### Review hardening (caught before release)
+
+- `handler.Invoke` member access resolves to the delegate type's `Invoke` method and is never
+  flagged — the developer cannot change that signature.
+- Handlers defined in another assembly (metadata) are never flagged — no editable signature exists
+  in the solution.
+- Parenthesized method groups (`(Handler)`) and generic method groups (`Handler<T>`) no longer
+  evade analysis.
+- The fix is withheld for **virtual/abstract** handlers (rewriting the base would orphan overrides,
+  CS0115) and **partial** methods (both parts must keep matching signatures, CS8795); the
+  diagnostic still reports for manual action.
+- Fix All on two routes sharing one handler adds the token parameter exactly once (pinned by test).
+- The rewritten declaration now carries the formatter annotation, matching the CC001 fix.
+
 ## [1.4.3] - 2026-06-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.4] - 2026-06-09
+
+### Added
+
+- **CC005C** (`MinimalApiAnalyzer`) now analyses **method-group handlers**, not just lambdas:
+  `app.MapGet("/users", GetUsersAsync)`, `app.MapGet("/users", UserHandlers.Get)`, and local-function
+  method groups are resolved to the referenced method, which is flagged when it is async-shaped
+  (`async` or Task/ValueTask-returning) without a `CancellationToken` parameter. Synchronous
+  handlers, delegate-typed variables, ambiguous method groups, and externally-controlled signatures
+  (override/interface/extern) stay quiet.
+- The CC005C **code fix** follows: for a method-group diagnostic it adds
+  `CancellationToken cancellationToken = default` to the referenced method or local function
+  (`= default` keeps any other call sites compiling). Only same-document declarations are rewritten;
+  a handler defined in another file keeps the diagnostic but gets no automatic fix.
+
+### Fixed
+
+- The CC005C lambda code fix now matches the diagnostic span exactly, so a CC005C diagnostic can
+  never be "fixed" by adding a token parameter to an unrelated enclosing lambda (e.g. a registration
+  lambda wrapping the `MapGet` call).
+
 ## [1.4.3] - 2026-06-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ app.MapGet("/users", async () => await GetUsersAsync());
 
 // ✅ Fixed
 app.MapGet("/users", async (CancellationToken ct) => await GetUsersAsync(ct));
+
+// ❌ Warning CC005C — method-group handlers are analysed too (v1.4.4);
+// the fix adds `CancellationToken cancellationToken = default` to GetUsersAsync itself
+app.MapGet("/users", GetUsersAsync);
 ```
 
 ### CC006: Token Not Last Parameter

--- a/docs/ANALYZER_HEALTH.md
+++ b/docs/ANALYZER_HEALTH.md
@@ -68,13 +68,24 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 - **Extract the shared report pipeline.** CC002/CC003/CC004 now end in a verbatim ~35-line block
   (token-argument check → scope walk → expression-tree guard → overload check → report). One helper
   would prevent the three-way drift this loop just fixed from recurring.
+- **Dedupe the add-token-to-declaration recipe.** The CC005C method-group fix and the CC001 fix
+  both build `CancellationToken cancellationToken = default` and insert it via
+  `InsertTokenParameter`; the method-group symbol resolution (symbol-or-single-candidate) is also
+  duplicated between `MinimalApiAnalyzer` and `MinimalApiCodeFixProvider`. Shared helpers would
+  keep analyzer and fixer matching in lockstep.
+- **CC005C → CC002 cascade.** Applying the CC005C method-group fix gives the handler a token that
+  its body does not yet propagate, so CC002/CC003/CC004 fire next — an intentional guided sequence,
+  but worth documenting (and a combined-analyzer test would pin it).
 
 ### Resolved
-- ~~**CC005C method-group handlers** (v1.4.4).~~ `app.MapGet("/", Handler)`, `Handlers.Get`, and
-  local-function method groups are resolved to the referenced method and flagged when async-shaped
-  without a token; the fixer adds `CancellationToken cancellationToken = default` to the referenced
-  declaration (same-document only). The lambda fixer now also matches the diagnostic span exactly so
-  it cannot patch an unrelated enclosing lambda. Pinned by 9 new tests.
+- ~~**CC005C method-group handlers** (v1.4.4).~~ `app.MapGet("/", Handler)`, `Handlers.Get`,
+  `Handler<T>`, `(Handler)`, and local-function method groups are resolved to the referenced method
+  and flagged when async-shaped without a token; the fixer adds
+  `CancellationToken cancellationToken = default` to the referenced declaration (same-document
+  only). Review hardening: `handler.Invoke` and metadata methods never flag; virtual/abstract and
+  partial handlers report but get no automatic fix (CS0115/CS8795 guards); Fix All on a shared
+  handler adds the parameter once; the lambda fixer matches the diagnostic span exactly so it
+  cannot patch an unrelated enclosing lambda. Pinned by 16 new tests.
 - ~~**CC003 / CC004 scope consistency** (v1.4.3).~~ Both now use the shared
   `FindEnclosingCancellationTokenParameter` walk (local functions, lambdas, containing method) and
   CC002's expression-tree guard; pinned by 9 new tests (5 EF Core, 4 HttpClient), including an
@@ -113,11 +124,13 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 
 ## Verification Baseline
 
-- `dotnet test CancelCop.sln` — 177 passed, 0 failed after the CC005C method-group support
-  (168 after v1.4.3 + 9 new tests).
-- `dotnet test … --filter FullyQualifiedName~MinimalApi` — 27 passed (18 prior + 6 analyzer tests:
-  method group/member-access/local-function positives, with-token/synchronous/delegate-variable
-  negatives + 3 fixer tests: method, local function, and fix-targets-method-not-enclosing-lambda).
+- `dotnet test CancelCop.sln` — 184 passed, 0 failed after the CC005C method-group support and its
+  review hardening (168 after v1.4.3 + 16 new tests).
+- `dotnet test … --filter FullyQualifiedName~MinimalApi` — 34 passed (18 prior + 10 analyzer tests:
+  method group/member-access/local-function/generic/parenthesized positives,
+  with-token/synchronous/delegate-variable/delegate-Invoke/metadata negatives + 6 fixer tests:
+  method, local function, fix-targets-method-not-enclosing-lambda, virtual no-fix, partial no-fix,
+  Fix All shared handler).
 - `dotnet test … --filter "FullyQualifiedName~EFCore|FullyQualifiedName~HttpClient"` — 39 passed
   (27 prior + 12 new: local-function/lambda/captured-token positives, no-token and static-function
   negatives, anonymous-method positive, and an EF expression-tree negative).

--- a/docs/ANALYZER_HEALTH.md
+++ b/docs/ANALYZER_HEALTH.md
@@ -1,6 +1,6 @@
 # Analyzer Health
 
-Reviewed: 2026-06-09 (refreshed through the v1.4.3 hardening loop)
+Reviewed: 2026-06-09 (refreshed through the v1.4.4 hardening loop)
 
 A deliberately harsh health audit for the nine implemented CancelCop rule IDs (CC001–CC006, CC009).
 Scores are 1–5, where `5` means reference-quality and hard to improve, `3` means usable but
@@ -36,7 +36,7 @@ Calibration notes:
 | CC004 | HttpClient async call missing CancellationToken | Usage | Warning | 4 | 4 | 4 | 4 | 3 | 4 | Low | **v1.4.3:** same shared scope walk + expression-tree guard as CC003. Type-gated to `System.Net.Http.HttpClient`, overload-checked. No analyzer XML doc (P3). |
 | CC005A | MediatR handler missing CancellationToken | Usage | Warning | 3 | 4 | 4 | 4 | 3 | 2 | Low | Gated to `MediatR.IRequestHandler.Handle`. Real MediatR's interface already mandates the token, so the rule mostly assists a non-compiling handler rather than catching a live omission — low product importance. Uses an inline token check instead of the shared helper. |
 | CC005B | Controller action missing CancellationToken | Usage | Warning | 4 | 4 | 4 | 4 | 3 | 4 | Low | Heavily hardened in v1.4.0: public non-static, `ControllerBase`/`Controller` by namespace, inherited `[NonAction]`, MVC HTTP-method attribute by identity + subclass. Conservative and accurate. |
-| CC005C | Minimal API handler missing CancellationToken | Usage | Warning | 4 | 4 | 4 | 4 | 3 | 4 | Low | **v1.4.1:** now gated on the receiver implementing `Microsoft.AspNetCore.Routing.IEndpointRouteBuilder`, so an unrelated `MapGet`-named method no longer false-positives (closes the last name-only match in the CC005 family). Remaining false negatives (both pre-existing, low value): method-group handlers (`app.MapGet("/", Handler)`) and the unreduced static-call form (`EndpointRouteBuilderExtensions.MapGet(app, …)`) are not analysed. |
+| CC005C | Minimal API handler missing CancellationToken | Usage | Warning | 4 | 4 | 4 | 4 | 3 | 4 | Low | **v1.4.4:** method-group handlers (`app.MapGet("/", Handler)`, `Handlers.Get`, local functions) are now analysed and fixed (token added to the referenced declaration, `= default`, same-document only). v1.4.1 gated the receiver on `IEndpointRouteBuilder`. Remaining false negative (pre-existing, low value): the unreduced static-call form (`EndpointRouteBuilderExtensions.MapGet(app, …)`). |
 | CC006 | CancellationToken should be last parameter | Style | Info | 4 | 4 | n/a | 4 | 3 | 2 | Low | v1.4.0: methods, constructors, primary constructors, local functions; excludes externally-controlled signatures and unmovable tokens (before trailing `params`, extension `this`). Analyzer-only by design (reordering would touch every call site). Convention rule, low importance. |
 | CC009 | Loop missing cancellation check | Usage | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | v1.4.0: semantic receiver resolution (no name matching), walks methods/local functions/lambdas, all four loop kinds, fixer inserts `ThrowIfCancellationRequested()`. The strongest rule in the set. |
 
@@ -56,15 +56,12 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 - _None._
 
 ### P1 — Next hardening loop
-- **CC005C method-group handlers.** Minimal APIs accept method groups (`app.MapGet("/", Handler)`), not
-  just lambdas. Analyse the referenced method's signature for a token parameter. _(Promoted from P2 —
-  next-largest real false-negative class now that scope walking is unified; loop 4 target.)_
+- **Constructor / primary-constructor token parameters** *(promoted from P2 — the largest remaining
+  false-negative class; loop 5 target)*. The shared scope walk only terminates at
+  `MethodDeclarationSyntax`; a `CancellationToken` declared on a constructor, accessor, or C# 12
+  primary constructor is never found, so CC002/CC003/CC004/CC009 stay silent there.
 
 ### P2 — Opportunistic
-- **Constructor / primary-constructor token parameters.** The shared scope walk only terminates at
-  `MethodDeclarationSyntax`; a `CancellationToken` declared on a constructor, accessor, or C# 12
-  primary constructor is never found, so CC002/CC003/CC004/CC009 stay silent there (false negative,
-  parity with pre-v1.4.3 behaviour).
 - **Named-argument code fixes.** The CC003/CC004 fixers append a positional token argument; on a call
   using out-of-position named arguments (`PostAsync(content: body, requestUri: url)`) the fixed call
   hits CS8323. Needs a named-argument-aware insertion (`cancellationToken: ct`).
@@ -73,6 +70,11 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
   would prevent the three-way drift this loop just fixed from recurring.
 
 ### Resolved
+- ~~**CC005C method-group handlers** (v1.4.4).~~ `app.MapGet("/", Handler)`, `Handlers.Get`, and
+  local-function method groups are resolved to the referenced method and flagged when async-shaped
+  without a token; the fixer adds `CancellationToken cancellationToken = default` to the referenced
+  declaration (same-document only). The lambda fixer now also matches the diagnostic span exactly so
+  it cannot patch an unrelated enclosing lambda. Pinned by 9 new tests.
 - ~~**CC003 / CC004 scope consistency** (v1.4.3).~~ Both now use the shared
   `FindEnclosingCancellationTokenParameter` walk (local functions, lambdas, containing method) and
   CC002's expression-tree guard; pinned by 9 new tests (5 EF Core, 4 HttpClient), including an
@@ -111,8 +113,11 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 
 ## Verification Baseline
 
-- `dotnet test CancelCop.sln` — 168 passed, 0 failed after the CC003/CC004 scope-walk fix plus the
-  static/anonymous-function hardening (154 after v1.4.2 + 14 new tests).
+- `dotnet test CancelCop.sln` — 177 passed, 0 failed after the CC005C method-group support
+  (168 after v1.4.3 + 9 new tests).
+- `dotnet test … --filter FullyQualifiedName~MinimalApi` — 27 passed (18 prior + 6 analyzer tests:
+  method group/member-access/local-function positives, with-token/synchronous/delegate-variable
+  negatives + 3 fixer tests: method, local function, and fix-targets-method-not-enclosing-lambda).
 - `dotnet test … --filter "FullyQualifiedName~EFCore|FullyQualifiedName~HttpClient"` — 39 passed
   (27 prior + 12 new: local-function/lambda/captured-token positives, no-token and static-function
   negatives, anonymous-method positive, and an EF expression-tree negative).

--- a/samples/CancelCop.Sample/CC005_HandlerPatterns.cs
+++ b/samples/CancelCop.Sample/CC005_HandlerPatterns.cs
@@ -112,7 +112,8 @@ public static class CC005_HandlerPatterns
     // CC005C: Minimal API Endpoint Pattern
     // =========================================================================
     //
-    // Minimal APIs use lambda expressions for endpoint handlers.
+    // Minimal APIs accept lambda or method-group endpoint handlers; both are analysed
+    // (method groups as of v1.4.4).
     //
     // VIOLATION:
     // ```csharp
@@ -134,6 +135,15 @@ public static class CC005_HandlerPatterns
     //     var user = await service.GetUserAsync(id, cancellationToken);
     //     return Results.Ok(user);
     // });
+    // ```
+    //
+    // METHOD-GROUP VIOLATION (the code fix adds the token to the referenced method):
+    // ```csharp
+    // app.MapGet("/users", GetUsersAsync);                       // CC005C WARNING
+    // static async Task<string> GetUsersAsync() { ... }
+    //
+    // app.MapGet("/users", GetUsersAsync);                       // fixed
+    // static async Task<string> GetUsersAsync(CancellationToken cancellationToken = default) { ... }
     // ```
 
     // =========================================================================

--- a/src/CancelCop.Analyzer.CodeFixes/MinimalApiCodeFixProvider.cs
+++ b/src/CancelCop.Analyzer.CodeFixes/MinimalApiCodeFixProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
 
 namespace CancelCop.Analyzer;
 
@@ -41,7 +42,7 @@ public class MinimalApiCodeFixProvider : CodeFixProvider
             .OfType<ExpressionSyntax>()
             .FirstOrDefault(e => e.Span == diagnosticSpan);
 
-        if (handlerExpression is IdentifierNameSyntax or MemberAccessExpressionSyntax)
+        if (handlerExpression is SimpleNameSyntax or MemberAccessExpressionSyntax)
         {
             await RegisterMethodGroupFixAsync(context, root, handlerExpression, diagnostic).ConfigureAwait(false);
             return;
@@ -87,6 +88,18 @@ public class MinimalApiCodeFixProvider : CodeFixProvider
             handlerMethod = symbolInfo.CandidateSymbols[0] as IMethodSymbol;
         if (handlerMethod == null)
             return;
+
+        // A partial method has two declaration parts that must keep matching signatures
+        // (CS8795/CS0759); rewriting only one part would not compile. A virtual or abstract
+        // method's signature is mirrored by its overrides, which a single-declaration rewrite
+        // would orphan (CS0115). Both keep the diagnostic but get no automatic fix.
+        if (handlerMethod.PartialDefinitionPart != null ||
+            handlerMethod.PartialImplementationPart != null ||
+            handlerMethod.IsVirtual ||
+            handlerMethod.IsAbstract)
+        {
+            return;
+        }
 
         var declaration = handlerMethod.DeclaringSyntaxReferences.FirstOrDefault()
             ?.GetSyntax(context.CancellationToken);
@@ -143,6 +156,7 @@ public class MinimalApiCodeFixProvider : CodeFixProvider
             LocalFunctionStatementSyntax f => f.WithParameterList(newParameterList),
             _ => declaration,
         };
+        newDeclaration = newDeclaration.WithAdditionalAnnotations(Formatter.Annotation);
 
         var newRoot = root.ReplaceNode(declaration, newDeclaration);
 

--- a/src/CancelCop.Analyzer.CodeFixes/MinimalApiCodeFixProvider.cs
+++ b/src/CancelCop.Analyzer.CodeFixes/MinimalApiCodeFixProvider.cs
@@ -35,9 +35,23 @@ public class MinimalApiCodeFixProvider : CodeFixProvider
         if (node == null)
             return;
 
+        // A method-group diagnostic spans the handler reference (`Handler` / `Handlers.Get`).
+        // The fix targets the referenced method's declaration, not anything at the call site.
+        var handlerExpression = node.AncestorsAndSelf()
+            .OfType<ExpressionSyntax>()
+            .FirstOrDefault(e => e.Span == diagnosticSpan);
+
+        if (handlerExpression is IdentifierNameSyntax or MemberAccessExpressionSyntax)
+        {
+            await RegisterMethodGroupFixAsync(context, root, handlerExpression, diagnostic).ConfigureAwait(false);
+            return;
+        }
+
+        // Lambda diagnostics span the whole lambda; matching on the exact span keeps a
+        // diagnostic reported elsewhere from being "fixed" on an enclosing lambda.
         var parenthesizedLambda = node.AncestorsAndSelf()
             .OfType<ParenthesizedLambdaExpressionSyntax>()
-            .FirstOrDefault();
+            .FirstOrDefault(l => l.Span == diagnosticSpan);
 
         if (parenthesizedLambda != null)
         {
@@ -55,6 +69,87 @@ public class MinimalApiCodeFixProvider : CodeFixProvider
         // typed CancellationToken would mix typed/untyped parameters (CS0748), and an untyped
         // token is not recognized as a CancellationToken (the fix would re-fire). Such a lambda
         // is not a bindable minimal-API handler anyway, so no safe fix can be offered — skip it.
+    }
+
+    private static async Task RegisterMethodGroupFixAsync(
+        CodeFixContext context,
+        SyntaxNode root,
+        ExpressionSyntax handlerExpression,
+        Diagnostic diagnostic)
+    {
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel == null)
+            return;
+
+        var symbolInfo = semanticModel.GetSymbolInfo(handlerExpression, context.CancellationToken);
+        var handlerMethod = symbolInfo.Symbol as IMethodSymbol;
+        if (handlerMethod == null && symbolInfo.CandidateSymbols.Length == 1)
+            handlerMethod = symbolInfo.CandidateSymbols[0] as IMethodSymbol;
+        if (handlerMethod == null)
+            return;
+
+        var declaration = handlerMethod.DeclaringSyntaxReferences.FirstOrDefault()
+            ?.GetSyntax(context.CancellationToken);
+
+        // Only same-document declarations are rewritten; a handler defined in another file keeps
+        // the diagnostic but gets no automatic fix (the fix-all scope would otherwise surprise).
+        if (declaration?.SyntaxTree != root.SyntaxTree)
+            return;
+
+        // The handler can be a method or a local function — both carry a parameter list.
+        if (declaration is not MethodDeclarationSyntax and not LocalFunctionStatementSyntax)
+            return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Title,
+                createChangedDocument: c => AddCancellationTokenToHandlerDeclarationAsync(
+                    context.Document, declaration, c),
+                equivalenceKey: Title),
+            diagnostic);
+    }
+
+    private static async Task<Document> AddCancellationTokenToHandlerDeclarationAsync(
+        Document document,
+        SyntaxNode declaration,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root == null)
+            return document;
+
+        var (parameterList, body) = declaration switch
+        {
+            MethodDeclarationSyntax m => (m.ParameterList, m.Body ?? (SyntaxNode?)m.ExpressionBody),
+            LocalFunctionStatementSyntax f => (f.ParameterList, f.Body ?? (SyntaxNode?)f.ExpressionBody),
+            _ => (null, null),
+        };
+        if (parameterList == null)
+            return document;
+
+        var tokenName = CancellationTokenFixHelpers.GetUniqueTokenParameterName(parameterList, body);
+
+        // `= default` keeps any other existing call sites of the handler compiling; ASP.NET Core
+        // binds the parameter regardless of the default.
+        var tokenParameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier(tokenName))
+            .WithType(SyntaxFactory.ParseTypeName("CancellationToken"))
+            .WithDefault(CancellationTokenFixHelpers.DefaultValueClause());
+
+        var newParameterList = CancellationTokenFixHelpers.InsertTokenParameter(parameterList, tokenParameter);
+
+        var newDeclaration = declaration switch
+        {
+            MethodDeclarationSyntax m => (SyntaxNode)m.WithParameterList(newParameterList),
+            LocalFunctionStatementSyntax f => f.WithParameterList(newParameterList),
+            _ => declaration,
+        };
+
+        var newRoot = root.ReplaceNode(declaration, newDeclaration);
+
+        if (newRoot is CompilationUnitSyntax compilationUnit)
+            newRoot = CancellationTokenFixHelpers.AddSystemThreadingUsing(compilationUnit);
+
+        return document.WithSyntaxRoot(newRoot);
     }
 
     private static async Task<Document> AddCancellationTokenToParenthesizedLambdaAsync(

--- a/src/CancelCop.Analyzer.Package/CancelCop.Analyzer.Package.csproj
+++ b/src/CancelCop.Analyzer.Package/CancelCop.Analyzer.Package.csproj
@@ -13,7 +13,7 @@
         <PackageId>CancelCop.Analyzer</PackageId>
         <!-- Fallback for local packs; the publish workflow overrides this with -p:Version from
              the release tag so the published package always matches the tag. -->
-        <Version>1.4.3</Version>
+        <Version>1.4.4</Version>
         <Authors>George Wall</Authors>
         <Description>A surgical Roslyn analyzer focused on CancellationToken best practices: propagation, parameter positioning, loop cancellation checks, and more. Includes automatic code fixes for public APIs, handlers, EF Core, HTTP calls, and Minimal APIs.</Description>
         <PackageTags>roslyn;analyzer;cancellationtoken;async;code-fix;loops;efcore;httpclient</PackageTags>

--- a/src/CancelCop.Analyzer/MinimalApiAnalyzer.cs
+++ b/src/CancelCop.Analyzer/MinimalApiAnalyzer.cs
@@ -73,7 +73,16 @@ public class MinimalApiAnalyzer : DiagnosticAnalyzer
 
         var handlerArgument = arguments[1].Expression;
 
-        // Check if it's a lambda expression
+        // Method-group handlers (`app.MapGet("/", Handler)` or `app.MapGet("/", Handlers.Get)`)
+        // reference a declared method whose signature we can inspect directly.
+        if (handlerArgument is IdentifierNameSyntax or MemberAccessExpressionSyntax)
+        {
+            AnalyzeMethodGroupHandler(context, handlerArgument, methodName);
+            return;
+        }
+
+        // Otherwise only lambda handlers are analysed; delegate variables and other expressions
+        // are not bound to an inspectable signature here.
         if (handlerArgument is not ParenthesizedLambdaExpressionSyntax and not SimpleLambdaExpressionSyntax)
             return;
 
@@ -110,6 +119,48 @@ public class MinimalApiAnalyzer : DiagnosticAnalyzer
         }
 
         // Report diagnostic on the lambda expression
+        var diagnostic = Diagnostic.Create(
+            Rule,
+            handlerArgument.GetLocation(),
+            methodName);
+
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    /// <summary>
+    /// Analyses a method-group handler argument: resolves the referenced method and reports when
+    /// it is async-shaped (async modifier or Task/ValueTask-returning) without a
+    /// <c>CancellationToken</c> parameter.
+    /// </summary>
+    private static void AnalyzeMethodGroupHandler(
+        SyntaxNodeAnalysisContext context,
+        ExpressionSyntax handlerArgument,
+        string methodName)
+    {
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(handlerArgument);
+
+        // A method group converted to System.Delegate may bind directly (C# 10 natural type) or
+        // surface as a single candidate. A delegate-typed variable resolves to a local/field
+        // symbol instead and is filtered out here. Multiple candidates mean an ambiguous group —
+        // stay quiet rather than guess.
+        var handlerMethod = symbolInfo.Symbol as IMethodSymbol;
+        if (handlerMethod == null && symbolInfo.CandidateSymbols.Length == 1)
+            handlerMethod = symbolInfo.CandidateSymbols[0] as IMethodSymbol;
+        if (handlerMethod == null)
+            return;
+
+        // Mirror the lambda path's async-only gating: a synchronous handler returning a plain
+        // value has nothing to cancel.
+        if (!handlerMethod.IsAsync && !CancellationTokenHelpers.IsAsyncReturnType(handlerMethod.ReturnType))
+            return;
+
+        if (CancellationTokenHelpers.HasCancellationTokenParameter(handlerMethod))
+            return;
+
+        // The developer cannot add a parameter to an override/interface/extern signature here.
+        if (CancellationTokenHelpers.IsSignatureExternallyControlled(handlerMethod))
+            return;
+
         var diagnostic = Diagnostic.Create(
             Rule,
             handlerArgument.GetLocation(),

--- a/src/CancelCop.Analyzer/MinimalApiAnalyzer.cs
+++ b/src/CancelCop.Analyzer/MinimalApiAnalyzer.cs
@@ -73,9 +73,13 @@ public class MinimalApiAnalyzer : DiagnosticAnalyzer
 
         var handlerArgument = arguments[1].Expression;
 
-        // Method-group handlers (`app.MapGet("/", Handler)` or `app.MapGet("/", Handlers.Get)`)
+        // A parenthesized handler is the same handler: `(Handler)` must not evade analysis.
+        while (handlerArgument is ParenthesizedExpressionSyntax parenthesized)
+            handlerArgument = parenthesized.Expression;
+
+        // Method-group handlers (`app.MapGet("/", Handler)`, `Handlers.Get`, `Handler<T>`)
         // reference a declared method whose signature we can inspect directly.
-        if (handlerArgument is IdentifierNameSyntax or MemberAccessExpressionSyntax)
+        if (handlerArgument is SimpleNameSyntax or MemberAccessExpressionSyntax)
         {
             AnalyzeMethodGroupHandler(context, handlerArgument, methodName);
             return;
@@ -147,6 +151,15 @@ public class MinimalApiAnalyzer : DiagnosticAnalyzer
         if (handlerMethod == null && symbolInfo.CandidateSymbols.Length == 1)
             handlerMethod = symbolInfo.CandidateSymbols[0] as IMethodSymbol;
         if (handlerMethod == null)
+            return;
+
+        // `handler.Invoke` resolves to the delegate type's Invoke method — its signature belongs
+        // to the delegate type, not to anything the developer can change here.
+        if (handlerMethod.ContainingType?.TypeKind == TypeKind.Delegate)
+            return;
+
+        // A handler defined in another assembly has no editable signature in this solution.
+        if (handlerMethod.DeclaringSyntaxReferences.Length == 0)
             return;
 
         // Mirror the lambda path's async-only gating: a synchronous handler returning a plain

--- a/tests/CancelCop.Analyzer.Tests/MinimalApiAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/MinimalApiAnalyzerTests.cs
@@ -480,6 +480,112 @@ public class Program
     }
 
     [Fact]
+    public async Task MapGet_GenericMethodGroupWithoutToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", {|#0:GetItemsAsync<string>|});
+    }
+
+    private static async Task<string> GetItemsAsync<T>()
+    {
+        await Task.Delay(100);
+        return ""items"";
+    }
+}";
+
+        var expected = new DiagnosticResult("CC005C", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("MapGet");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
+    public async Task MapGet_ParenthesizedMethodGroupWithoutToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", ({|#0:GetUsersAsync|}));
+    }
+
+    private static async Task<string> GetUsersAsync()
+    {
+        await Task.Delay(100);
+        return ""users"";
+    }
+}";
+
+        var expected = new DiagnosticResult("CC005C", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("MapGet");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
+    public async Task MapGet_DelegateInvokeMemberAccess_ShouldNotReportDiagnostic()
+    {
+        // handler.Invoke resolves to the delegate type's Invoke method, whose signature the
+        // developer cannot change — must stay quiet like the bare delegate variable.
+        var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        Func<Task<string>> handler = async () => { await Task.Delay(100); return ""users""; };
+        app.MapGet(""/users"", handler.Invoke);
+    }
+}";
+
+        await CreateTest(test).RunAsync();
+    }
+
+    [Fact]
+    public async Task MapGet_MetadataMethodGroup_ShouldNotReportDiagnostic()
+    {
+        // A handler defined in another assembly has no editable signature in this solution.
+        // TextWriter.DisposeAsync is a unique, ValueTask-returning, tokenless metadata method —
+        // async-shaped, so only the metadata guard keeps it quiet.
+        var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/dispose"", Console.Error.DisposeAsync);
+    }
+}";
+
+        await CreateTest(test).RunAsync();
+    }
+
+    [Fact]
     public async Task MapGet_DelegateVariable_ShouldNotReportDiagnostic()
     {
         // A delegate-typed variable is not a method group; its target signature is not bound

--- a/tests/CancelCop.Analyzer.Tests/MinimalApiAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/MinimalApiAnalyzerTests.cs
@@ -337,4 +337,168 @@ public class Program
 
         await CreateTest(test).RunAsync();
     }
+
+    [Fact]
+    public async Task MapGet_MethodGroupWithoutToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", {|#0:GetUsersAsync|});
+    }
+
+    private static async Task<string> GetUsersAsync()
+    {
+        await Task.Delay(100);
+        return ""users"";
+    }
+}";
+
+        var expected = new DiagnosticResult("CC005C", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("MapGet");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
+    public async Task MapGet_MemberAccessMethodGroupWithoutToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public static class UserHandlers
+{
+    public static async Task<string> Get()
+    {
+        await Task.Delay(100);
+        return ""users"";
+    }
+}
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", {|#0:UserHandlers.Get|});
+    }
+}";
+
+        var expected = new DiagnosticResult("CC005C", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("MapGet");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
+    public async Task MapGet_MethodGroupWithToken_ShouldNotReportDiagnostic()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", GetUsersAsync);
+    }
+
+    private static async Task<string> GetUsersAsync(CancellationToken cancellationToken)
+    {
+        await Task.Delay(100, cancellationToken);
+        return ""users"";
+    }
+}";
+
+        await CreateTest(test).RunAsync();
+    }
+
+    [Fact]
+    public async Task MapGet_LocalFunctionMethodGroupWithoutToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", {|#0:GetUsersAsync|});
+
+        static async Task<string> GetUsersAsync()
+        {
+            await Task.Delay(100);
+            return ""users"";
+        }
+    }
+}";
+
+        var expected = new DiagnosticResult("CC005C", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("MapGet");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
+    public async Task MapGet_SynchronousMethodGroup_ShouldNotReportDiagnostic()
+    {
+        // A synchronous handler returning a plain value has nothing to cancel — mirrors the
+        // lambda path, which only fires on async lambdas.
+        var test = @"
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", GetUsers);
+    }
+
+    private static string GetUsers() => ""users"";
+}";
+
+        await CreateTest(test).RunAsync();
+    }
+
+    [Fact]
+    public async Task MapGet_DelegateVariable_ShouldNotReportDiagnostic()
+    {
+        // A delegate-typed variable is not a method group; its target signature is not bound
+        // here, so the analyzer stays quiet.
+        var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        Func<Task<string>> handler = async () => { await Task.Delay(100); return ""users""; };
+        app.MapGet(""/users"", handler);
+    }
+}";
+
+        await CreateTest(test).RunAsync();
+    }
 }

--- a/tests/CancelCop.Analyzer.Tests/MinimalApiCodeFixTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/MinimalApiCodeFixTests.cs
@@ -418,4 +418,188 @@ public class Program
         test2.ExpectedDiagnostics.Add(expected);
         await test2.RunAsync();
     }
+
+    [Fact]
+    public async Task MapGet_MethodGroup_AddsTokenToReferencedMethod()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", {|#0:GetUsersAsync|});
+    }
+
+    private static async Task<string> GetUsersAsync()
+    {
+        await Task.Delay(100);
+        return ""users"";
+    }
+}";
+
+        var fixedCode = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", GetUsersAsync);
+    }
+
+    private static async Task<string> GetUsersAsync(CancellationToken cancellationToken = default)
+    {
+        await Task.Delay(100);
+        return ""users"";
+    }
+}";
+
+        var expected = new DiagnosticResult("CC005C", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("MapGet");
+
+        var test2 = new CSharpCodeFixTest<MinimalApiAnalyzer, MinimalApiCodeFixProvider, DefaultVerifier>
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90
+                .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.AspNetCore.App.Ref", "9.0.0"))),
+        };
+
+        test2.ExpectedDiagnostics.Add(expected);
+        await test2.RunAsync();
+    }
+
+    [Fact]
+    public async Task MapGet_LocalFunctionMethodGroup_AddsTokenToLocalFunction()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", {|#0:GetUsersAsync|});
+
+        static async Task<string> GetUsersAsync()
+        {
+            await Task.Delay(100);
+            return ""users"";
+        }
+    }
+}";
+
+        var fixedCode = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", GetUsersAsync);
+
+        static async Task<string> GetUsersAsync(CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(100);
+            return ""users"";
+        }
+    }
+}";
+
+        var expected = new DiagnosticResult("CC005C", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("MapGet");
+
+        var test2 = new CSharpCodeFixTest<MinimalApiAnalyzer, MinimalApiCodeFixProvider, DefaultVerifier>
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90
+                .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.AspNetCore.App.Ref", "9.0.0"))),
+        };
+
+        test2.ExpectedDiagnostics.Add(expected);
+        await test2.RunAsync();
+    }
+
+    [Fact]
+    public async Task MapGet_MethodGroupInsideRegistrationLambda_FixesMethodNotEnclosingLambda()
+    {
+        // The diagnostic sits on the method-group identifier inside a registration lambda; the
+        // fix must rewrite the referenced method's declaration, not add a parameter to the
+        // enclosing lambda.
+        var test = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+public static class Endpoints
+{
+    public static void Register(IEndpointRouteBuilder app)
+    {
+        Action register = () => app.MapGet(""/users"", {|#0:GetUsersAsync|});
+        register();
+    }
+
+    private static async Task<string> GetUsersAsync()
+    {
+        await Task.Delay(100);
+        return ""users"";
+    }
+}";
+
+        var fixedCode = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+public static class Endpoints
+{
+    public static void Register(IEndpointRouteBuilder app)
+    {
+        Action register = () => app.MapGet(""/users"", GetUsersAsync);
+        register();
+    }
+
+    private static async Task<string> GetUsersAsync(CancellationToken cancellationToken = default)
+    {
+        await Task.Delay(100);
+        return ""users"";
+    }
+}";
+
+        var expected = new DiagnosticResult("CC005C", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("MapGet");
+
+        var test2 = new CSharpCodeFixTest<MinimalApiAnalyzer, MinimalApiCodeFixProvider, DefaultVerifier>
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90
+                .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.AspNetCore.App.Ref", "9.0.0"))),
+        };
+
+        test2.ExpectedDiagnostics.Add(expected);
+        await test2.RunAsync();
+    }
 }

--- a/tests/CancelCop.Analyzer.Tests/MinimalApiCodeFixTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/MinimalApiCodeFixTests.cs
@@ -602,4 +602,155 @@ public static class Endpoints
         test2.ExpectedDiagnostics.Add(expected);
         await test2.RunAsync();
     }
+
+    [Fact]
+    public async Task MapGet_VirtualMethodGroup_ReportsButOffersNoFix()
+    {
+        // Rewriting a virtual method's signature would orphan its overrides (CS0115), so the
+        // diagnostic stands but no automatic fix is offered.
+        var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+public class UserHandlers
+{
+    public virtual async Task<string> Get()
+    {
+        await Task.Delay(100);
+        return ""users"";
+    }
+}
+
+public static class Endpoints
+{
+    public static void Register(IEndpointRouteBuilder app, UserHandlers handlers)
+    {
+        app.MapGet(""/users"", {|#0:handlers.Get|});
+    }
+}";
+
+        var expected = new DiagnosticResult("CC005C", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("MapGet");
+
+        var test2 = new CSharpCodeFixTest<MinimalApiAnalyzer, MinimalApiCodeFixProvider, DefaultVerifier>
+        {
+            TestCode = source,
+            FixedCode = source,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90
+                .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.AspNetCore.App.Ref", "9.0.0"))),
+        };
+
+        test2.ExpectedDiagnostics.Add(expected);
+        await test2.RunAsync();
+    }
+
+    [Fact]
+    public async Task MapGet_PartialMethodGroup_ReportsButOffersNoFix()
+    {
+        // A partial method's two declaration parts must keep matching signatures; rewriting one
+        // part would not compile (CS8795/CS0759), so no automatic fix is offered.
+        var source = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public partial class Program
+{
+    public static partial Task<string> GetUsersAsync();
+
+    public static partial async Task<string> GetUsersAsync()
+    {
+        await Task.Delay(100);
+        return ""users"";
+    }
+
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", {|#0:GetUsersAsync|});
+    }
+}";
+
+        var expected = new DiagnosticResult("CC005C", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("MapGet");
+
+        var test2 = new CSharpCodeFixTest<MinimalApiAnalyzer, MinimalApiCodeFixProvider, DefaultVerifier>
+        {
+            TestCode = source,
+            FixedCode = source,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90
+                .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.AspNetCore.App.Ref", "9.0.0"))),
+        };
+
+        test2.ExpectedDiagnostics.Add(expected);
+        await test2.RunAsync();
+    }
+
+    [Fact]
+    public async Task MapGet_TwoRoutesSameHandler_FixAllAddsParameterOnce()
+    {
+        // Two endpoints referencing the same handler produce two diagnostics whose fixes edit
+        // the same declaration; the batch fixer must merge them into a single token parameter.
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", {|#0:GetUsersAsync|});
+        app.MapPost(""/users"", {|#1:GetUsersAsync|});
+    }
+
+    private static async Task<string> GetUsersAsync()
+    {
+        await Task.Delay(100);
+        return ""users"";
+    }
+}";
+
+        var fixedCode = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+public class Program
+{
+    public static void Main()
+    {
+        var app = WebApplication.Create();
+        app.MapGet(""/users"", GetUsersAsync);
+        app.MapPost(""/users"", GetUsersAsync);
+    }
+
+    private static async Task<string> GetUsersAsync(CancellationToken cancellationToken = default)
+    {
+        await Task.Delay(100);
+        return ""users"";
+    }
+}";
+
+        var test2 = new CSharpCodeFixTest<MinimalApiAnalyzer, MinimalApiCodeFixProvider, DefaultVerifier>
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90
+                .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.AspNetCore.App.Ref", "9.0.0"))),
+        };
+
+        test2.ExpectedDiagnostics.Add(new DiagnosticResult("CC005C", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("MapGet"));
+        test2.ExpectedDiagnostics.Add(new DiagnosticResult("CC005C", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(1)
+            .WithArguments("MapPost"));
+        await test2.RunAsync();
+    }
 }


### PR DESCRIPTION
## Summary

Loop 4 of the analyzer-health hardening loop — closes the P1 backlog item from `docs/ANALYZER_HEALTH.md`.

- **CC005C (`MinimalApiAnalyzer`)** now analyses **method-group handlers** — `app.MapGet("/users", GetUsersAsync)`, `app.MapGet("/users", UserHandlers.Get)`, and local-function method groups — by resolving the referenced method and flagging it when it is async-shaped (`async` or Task/ValueTask-returning) without a `CancellationToken` parameter.
- Conservative guards: synchronous handlers, delegate-typed variables, ambiguous method groups, and externally-controlled signatures (override/interface/extern) stay quiet.
- **Code fix**: adds `CancellationToken cancellationToken = default` to the referenced method or local function (`= default` keeps other call sites compiling). Same-document declarations only.
- **Fixer span guard**: the lambda fix now requires an exact diagnostic-span match, so a method-group diagnostic inside a registration lambda can never be "fixed" by patching the enclosing lambda.

## Tests

- 9 new tests (6 analyzer + 3 code fix), including a fix-targets-the-method-not-the-enclosing-lambda regression test.
- Full suite: **177 passed, 0 failed** (168 prior + 9 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)