### PR TITLE
fix: token-scope walk covers constructors and primary constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.5] - 2026-06-09
+
+### Fixed
+
+- The shared token-scope walk (CC002/CC003/CC004/CC009) now finds `CancellationToken` parameters
+  declared on **constructors** and **C# 12 primary constructors** (classes and records). Previously
+  the walk only terminated at method declarations, so all four rules were silent in these scopes:
+  ```csharp
+  public class Worker(CancellationToken cancellationToken)
+  {
+      public Task RunAsync() => Task.Delay(100);   // CC002: should pass cancellationToken
+  }
+
+  public TestClass(CancellationToken cancellationToken)
+  {
+      _init = Task.Delay(100);                     // CC002: should pass cancellationToken
+  }
+  ```
+  Primary-constructor tokens are also found from instance field initializers. The walk stays
+  conservative where capture is illegal: static members, static field initializers, and non-primary
+  constructor bodies (CS9105) never see the primary-constructor token, and operators end the search.
+
 ## [1.4.4] - 2026-06-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   conservative where capture is illegal: static members, static field initializers, and non-primary
   constructor bodies (CS9105) never see the primary-constructor token, and operators end the search.
 
+### Review hardening (caught before release)
+
+- **Static event-field initializers** get the same CS9105 guard as static fields (the walk now
+  matches `BaseFieldDeclarationSyntax`, covering `event` fields), so a lambda in a static event
+  initializer can no longer be told to capture an uncapturable primary-constructor token.
+- **Partial types** whose primary constructor is declared on another part are now resolved through
+  the type symbol, so instance members on any part see the token (capture across parts is legal).
+- CC002 and CC009 XML-doc scope descriptions updated to match the widened walk.
+
 ## [1.4.4] - 2026-06-09
 
 ### Added

--- a/docs/ANALYZER_HEALTH.md
+++ b/docs/ANALYZER_HEALTH.md
@@ -1,6 +1,6 @@
 # Analyzer Health
 
-Reviewed: 2026-06-09 (refreshed through the v1.4.4 hardening loop)
+Reviewed: 2026-06-09 (refreshed through the v1.4.5 hardening loop)
 
 A deliberately harsh health audit for the nine implemented CancelCop rule IDs (CC001–CC006, CC009).
 Scores are 1–5, where `5` means reference-quality and hard to improve, `3` means usable but
@@ -56,15 +56,13 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 - _None._
 
 ### P1 — Next hardening loop
-- **Constructor / primary-constructor token parameters** *(promoted from P2 — the largest remaining
-  false-negative class; loop 5 target)*. The shared scope walk only terminates at
-  `MethodDeclarationSyntax`; a `CancellationToken` declared on a constructor, accessor, or C# 12
-  primary constructor is never found, so CC002/CC003/CC004/CC009 stay silent there.
+- **Named-argument code fixes** *(promoted from P2 — the remaining known non-compiling-fix class;
+  loop 6 target)*. The CC003/CC004 fixers append a positional token argument; on a call using
+  out-of-position named arguments (`PostAsync(content: body, requestUri: url)`) the fixed call hits
+  CS8323. Needs a named-argument-aware insertion (`cancellationToken: ct`). Audit CC002's fixer for
+  the same pattern while there.
 
 ### P2 — Opportunistic
-- **Named-argument code fixes.** The CC003/CC004 fixers append a positional token argument; on a call
-  using out-of-position named arguments (`PostAsync(content: body, requestUri: url)`) the fixed call
-  hits CS8323. Needs a named-argument-aware insertion (`cancellationToken: ct`).
 - **Extract the shared report pipeline.** CC002/CC003/CC004 now end in a verbatim ~35-line block
   (token-argument check → scope walk → expression-tree guard → overload check → report). One helper
   would prevent the three-way drift this loop just fixed from recurring.
@@ -78,6 +76,12 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
   but worth documenting (and a combined-analyzer test would pin it).
 
 ### Resolved
+- ~~**Constructor / primary-constructor token parameters** (v1.4.5).~~ The shared walk now inspects
+  constructor parameter lists and, for tokenless non-static instance members and instance field
+  initializers, falls through to the containing type's primary-constructor parameters (classes and
+  records). Conservative guards: static members/initializers, non-primary constructor bodies
+  (CS9105), and operators never see the primary token; the first containing type ends the search.
+  Pinned by 10 new tests across CC002/CC003/CC004/CC009.
 - ~~**CC005C method-group handlers** (v1.4.4).~~ `app.MapGet("/", Handler)`, `Handlers.Get`,
   `Handler<T>`, `(Handler)`, and local-function method groups are resolved to the referenced method
   and flagged when async-shaped without a token; the fixer adds
@@ -124,8 +128,9 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 
 ## Verification Baseline
 
-- `dotnet test CancelCop.sln` — 184 passed, 0 failed after the CC005C method-group support and its
-  review hardening (168 after v1.4.3 + 16 new tests).
+- `dotnet test CancelCop.sln` — 194 passed, 0 failed after the constructor/primary-constructor
+  scope support (184 after v1.4.4 + 10 new tests: 7 CC002 incl. record/static/CS9105 negatives,
+  1 CC003 constructor, 1 CC004 primary-constructor, 1 CC009 primary-constructor).
 - `dotnet test … --filter FullyQualifiedName~MinimalApi` — 34 passed (18 prior + 10 analyzer tests:
   method group/member-access/local-function/generic/parenthesized positives,
   with-token/synchronous/delegate-variable/delegate-Invoke/metadata negatives + 6 fixer tests:

--- a/docs/ANALYZER_HEALTH.md
+++ b/docs/ANALYZER_HEALTH.md
@@ -79,9 +79,11 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 - ~~**Constructor / primary-constructor token parameters** (v1.4.5).~~ The shared walk now inspects
   constructor parameter lists and, for tokenless non-static instance members and instance field
   initializers, falls through to the containing type's primary-constructor parameters (classes and
-  records). Conservative guards: static members/initializers, non-primary constructor bodies
-  (CS9105), and operators never see the primary token; the first containing type ends the search.
-  Pinned by 10 new tests across CC002/CC003/CC004/CC009.
+  records), resolving through the type symbol when the primary constructor sits on another partial
+  part. Conservative guards: static members, static field **and event-field** initializers
+  (`BaseFieldDeclarationSyntax`), non-primary constructor bodies (CS9105), and operators never see
+  the primary token; the first containing type ends the search. Pinned by 12 new tests across
+  CC002/CC003/CC004/CC009.
 - ~~**CC005C method-group handlers** (v1.4.4).~~ `app.MapGet("/", Handler)`, `Handlers.Get`,
   `Handler<T>`, `(Handler)`, and local-function method groups are resolved to the referenced method
   and flagged when async-shaped without a token; the fixer adds
@@ -128,9 +130,10 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 
 ## Verification Baseline
 
-- `dotnet test CancelCop.sln` — 194 passed, 0 failed after the constructor/primary-constructor
-  scope support (184 after v1.4.4 + 10 new tests: 7 CC002 incl. record/static/CS9105 negatives,
-  1 CC003 constructor, 1 CC004 primary-constructor, 1 CC009 primary-constructor).
+- `dotnet test CancelCop.sln` — 196 passed, 0 failed after the constructor/primary-constructor
+  scope support and its review hardening (184 after v1.4.4 + 12 new tests: 9 CC002 incl.
+  record/static/CS9105/static-event-field negatives and a partial-type positive, 1 CC003
+  constructor, 1 CC004 primary-constructor, 1 CC009 primary-constructor).
 - `dotnet test … --filter FullyQualifiedName~MinimalApi` — 34 passed (18 prior + 10 analyzer tests:
   method group/member-access/local-function/generic/parenthesized positives,
   with-token/synchronous/delegate-variable/delegate-Invoke/metadata negatives + 6 fixer tests:

--- a/src/CancelCop.Analyzer.Package/CancelCop.Analyzer.Package.csproj
+++ b/src/CancelCop.Analyzer.Package/CancelCop.Analyzer.Package.csproj
@@ -13,7 +13,7 @@
         <PackageId>CancelCop.Analyzer</PackageId>
         <!-- Fallback for local packs; the publish workflow overrides this with -p:Version from
              the release tag so the published package always matches the tag. -->
-        <Version>1.4.4</Version>
+        <Version>1.4.5</Version>
         <Authors>George Wall</Authors>
         <Description>A surgical Roslyn analyzer focused on CancellationToken best practices: propagation, parameter positioning, loop cancellation checks, and more. Includes automatic code fixes for public APIs, handlers, EF Core, HTTP calls, and Minimal APIs.</Description>
         <PackageTags>roslyn;analyzer;cancellationtoken;async;code-fix;loops;efcore;httpclient</PackageTags>

--- a/src/CancelCop.Analyzer/CancellationTokenHelpers.cs
+++ b/src/CancelCop.Analyzer/CancellationTokenHelpers.cs
@@ -139,11 +139,15 @@ internal static class CancellationTokenHelpers
             }
             else if (current is OperatorDeclarationSyntax or ConversionOperatorDeclarationSyntax)
             {
-                // Operators are static and never declare a token.
+                // Classic operators are static and never declare a token. (C# 14 instance
+                // compound-assignment operators could capture a primary token, but staying quiet
+                // there is the conservative side.)
                 return null;
             }
-            else if (current is FieldDeclarationSyntax field)
+            else if (current is BaseFieldDeclarationSyntax field)
             {
+                // Covers field and event-field declarations alike: a static initializer runs
+                // without instance context, so the primary token is unavailable (CS9105).
                 if (field.Modifiers.Any(SyntaxKind.StaticKeyword))
                     return null;
             }
@@ -156,22 +160,51 @@ internal static class CancellationTokenHelpers
             {
                 // Reaching the type means every enclosing member was a tokenless non-static
                 // scope; the type's primary-constructor parameters (if any) are the last chance.
-                if (typeDeclaration.ParameterList != null)
-                {
-                    foreach (var parameter in typeDeclaration.ParameterList.Parameters)
-                    {
-                        if (semanticModel.GetDeclaredSymbol(parameter) is IParameterSymbol parameterSymbol &&
-                            IsCancellationToken(parameterSymbol.Type))
-                        {
-                            return parameterSymbol;
-                        }
-                    }
-                }
-
-                return null;
+                return FindPrimaryConstructorTokenParameter(typeDeclaration, semanticModel);
             }
 
             current = current.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Finds a <c>CancellationToken</c> among the type's primary-constructor parameters, looking
+    /// first at the syntactic parameter list and then — for partial types whose primary
+    /// constructor is declared on another part — through the type symbol's constructors.
+    /// </summary>
+    private static IParameterSymbol? FindPrimaryConstructorTokenParameter(
+        TypeDeclarationSyntax typeDeclaration,
+        SemanticModel semanticModel)
+    {
+        if (typeDeclaration.ParameterList != null)
+        {
+            foreach (var parameter in typeDeclaration.ParameterList.Parameters)
+            {
+                if (semanticModel.GetDeclaredSymbol(parameter) is IParameterSymbol parameterSymbol &&
+                    IsCancellationToken(parameterSymbol.Type))
+                {
+                    return parameterSymbol;
+                }
+            }
+
+            return null;
+        }
+
+        // A partial part without the parameter list: the primary constructor is the instance
+        // constructor whose declaring syntax is a type declaration (capture from any part is
+        // legal, so the token must still be found).
+        if (semanticModel.GetDeclaredSymbol(typeDeclaration) is INamedTypeSymbol typeSymbol)
+        {
+            foreach (var constructor in typeSymbol.InstanceConstructors)
+            {
+                foreach (var reference in constructor.DeclaringSyntaxReferences)
+                {
+                    if (reference.GetSyntax() is TypeDeclarationSyntax)
+                        return FindCancellationTokenParameter(constructor);
+                }
+            }
         }
 
         return null;

--- a/src/CancelCop.Analyzer/CancellationTokenHelpers.cs
+++ b/src/CancelCop.Analyzer/CancellationTokenHelpers.cs
@@ -85,9 +85,13 @@ internal static class CancellationTokenHelpers
     /// A local function or anonymous function that has no token of its own does not stop the
     /// search: an outer scope's token is captured and remains usable from the inner body — unless
     /// the inner function is <c>static</c>, which forbids capturing enclosing parameters
-    /// (CS8421/CS8820), so a tokenless static function ends the search with no token. Reaching the
-    /// containing method declaration also ends the search, because its parameter list is the
-    /// outermost local scope (class members are not parameters).
+    /// (CS8421/CS8820), so a tokenless static function ends the search with no token. A method or
+    /// constructor parameter list is the outermost <em>local</em> scope, but a tokenless
+    /// non-static member keeps searching one level further: a C# 12 primary-constructor parameter
+    /// is captured and usable from instance-member bodies and initializers. Static members cannot
+    /// capture primary-constructor parameters, and a non-primary constructor's body cannot
+    /// reference them (CS9105), so those end the search. The first containing type declaration
+    /// always ends the search — an outer type's parameters are never in scope.
     /// </remarks>
     public static IParameterSymbol? FindEnclosingCancellationTokenParameter(
         SyntaxNode node,
@@ -97,7 +101,7 @@ internal static class CancellationTokenHelpers
         while (current != null)
         {
             // Local function first (innermost), then lambda / anonymous method, then the
-            // containing method.
+            // containing member, then the containing type's primary constructor.
             if (current is LocalFunctionStatementSyntax localFunction)
             {
                 var token = FindCancellationTokenParameter(
@@ -116,10 +120,55 @@ internal static class CancellationTokenHelpers
                 if (anonymousFunction.Modifiers.Any(SyntaxKind.StaticKeyword))
                     return null;
             }
+            else if (current is ConstructorDeclarationSyntax constructor)
+            {
+                // A non-primary constructor's body cannot reference primary-constructor
+                // parameters (CS9105), so its own parameter list ends the search.
+                return FindCancellationTokenParameter(
+                    semanticModel.GetDeclaredSymbol(constructor) as IMethodSymbol);
+            }
             else if (current is MethodDeclarationSyntax method)
             {
-                return FindCancellationTokenParameter(
+                var token = FindCancellationTokenParameter(
                     semanticModel.GetDeclaredSymbol(method) as IMethodSymbol);
+                if (token != null)
+                    return token;
+                // A static member cannot capture primary-constructor parameters.
+                if (method.Modifiers.Any(SyntaxKind.StaticKeyword))
+                    return null;
+            }
+            else if (current is OperatorDeclarationSyntax or ConversionOperatorDeclarationSyntax)
+            {
+                // Operators are static and never declare a token.
+                return null;
+            }
+            else if (current is FieldDeclarationSyntax field)
+            {
+                if (field.Modifiers.Any(SyntaxKind.StaticKeyword))
+                    return null;
+            }
+            else if (current is BasePropertyDeclarationSyntax property)
+            {
+                if (property.Modifiers.Any(SyntaxKind.StaticKeyword))
+                    return null;
+            }
+            else if (current is TypeDeclarationSyntax typeDeclaration)
+            {
+                // Reaching the type means every enclosing member was a tokenless non-static
+                // scope; the type's primary-constructor parameters (if any) are the last chance.
+                if (typeDeclaration.ParameterList != null)
+                {
+                    foreach (var parameter in typeDeclaration.ParameterList.Parameters)
+                    {
+                        if (semanticModel.GetDeclaredSymbol(parameter) is IParameterSymbol parameterSymbol &&
+                            IsCancellationToken(parameterSymbol.Type))
+                        {
+                            return parameterSymbol;
+                        }
+                    }
+                }
+
+                return null;
             }
 
             current = current.Parent;

--- a/src/CancelCop.Analyzer/LoopCancellationAnalyzer.cs
+++ b/src/CancelCop.Analyzer/LoopCancellationAnalyzer.cs
@@ -38,8 +38,9 @@ namespace CancelCop.Analyzer;
 /// </para>
 /// <para>
 /// <b>Scope:</b>
-/// Only analyzes loops in methods, local functions, or lambdas that have a CancellationToken
-/// parameter available.
+/// Only analyzes loops in scopes with a CancellationToken parameter available: methods,
+/// constructors, local functions, lambdas, and instance members of C# 12 primary-constructor
+/// types whose primary constructor declares a token.
 /// </para>
 /// </remarks>
 /// <example>

--- a/src/CancelCop.Analyzer/TokenPropagationAnalyzer.cs
+++ b/src/CancelCop.Analyzer/TokenPropagationAnalyzer.cs
@@ -30,7 +30,9 @@ namespace CancelCop.Analyzer;
 /// </para>
 /// <para>
 /// <b>Scope:</b>
-/// Checks method bodies, local functions, and lambda expressions for token availability.
+/// Checks method bodies, constructors, local functions, lambda expressions, and anonymous
+/// methods for token availability, including C# 12 primary-constructor parameters captured by
+/// instance members and instance field initializers.
 /// </para>
 /// </remarks>
 /// <example>

--- a/tests/CancelCop.Analyzer.Tests/EFCoreAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/EFCoreAnalyzerTests.cs
@@ -408,6 +408,31 @@ public class User { public int Id { get; set; } }";
     }
 
     [Fact]
+    public async Task EFCoreMethod_InConstructorWithToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+public class Warmup
+{
+    private readonly Task<int> _seed;
+
+    public Warmup(DbContext context, CancellationToken cancellationToken)
+    {
+        _seed = context.{|#0:SaveChangesAsync|}();
+    }
+}";
+
+        var expected = new DiagnosticResult("CC003", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("SaveChangesAsync", "cancellationToken");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
     public async Task EFCoreMethod_NoTokenParameter_ShouldNotReportDiagnostic()
     {
         var test = @"

--- a/tests/CancelCop.Analyzer.Tests/HttpClientAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/HttpClientAnalyzerTests.cs
@@ -399,6 +399,29 @@ public class TestClass
     }
 
     [Fact]
+    public async Task HttpClientMethod_InPrimaryConstructorClassMethod_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Fetcher(HttpClient httpClient, CancellationToken cancellationToken)
+{
+    public async Task<string> FetchAsync()
+    {
+        return await httpClient.{|#0:GetStringAsync|}(""https://api.example.com"");
+    }
+}";
+
+        var expected = new DiagnosticResult("CC004", Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("GetStringAsync", "cancellationToken");
+
+        await CreateTest(test, expected).RunAsync();
+    }
+
+    [Fact]
     public async Task HttpClientMethod_InLambda_NoTokenAnywhere_ShouldNotReportDiagnostic()
     {
         var test = @"

--- a/tests/CancelCop.Analyzer.Tests/LoopCancellationAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/LoopCancellationAnalyzerTests.cs
@@ -433,4 +433,30 @@ public class TestClass
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
+
+    [Fact]
+    public async Task Loop_InPrimaryConstructorClassMethod_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Processor(CancellationToken cancellationToken)
+{
+    public async Task ProcessAsync(List<int> items)
+    {
+        {|#0:foreach|} (var item in items)
+        {
+            await Task.Delay(100, cancellationToken);
+        }
+    }
+}";
+
+        var expected = VerifyCS.Diagnostic("CC009")
+            .WithLocation(0)
+            .WithArguments("cancellationToken");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
 }

--- a/tests/CancelCop.Analyzer.Tests/TokenPropagationAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/TokenPropagationAnalyzerTests.cs
@@ -437,4 +437,146 @@ public class TestClass
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
+
+    [Fact]
+    public async Task Call_InConstructorWithToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+public class TestClass
+{
+    private readonly Task _init;
+
+    public TestClass(CancellationToken cancellationToken)
+    {
+        _init = Task.{|#0:Delay|}(100);
+    }
+}";
+
+        var expected = VerifyCS.Diagnostic("CC002")
+            .WithLocation(0)
+            .WithArguments("Delay", "cancellationToken");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Call_InInstanceMethodOfPrimaryConstructorClass_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Worker(CancellationToken cancellationToken)
+{
+    public Task RunAsync() => Task.{|#0:Delay|}(100);
+}";
+
+        var expected = VerifyCS.Diagnostic("CC002")
+            .WithLocation(0)
+            .WithArguments("Delay", "cancellationToken");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Call_InFieldInitializerOfPrimaryConstructorClass_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Worker(CancellationToken cancellationToken)
+{
+    private readonly Task _init = Task.{|#0:Delay|}(100);
+}";
+
+        var expected = VerifyCS.Diagnostic("CC002")
+            .WithLocation(0)
+            .WithArguments("Delay", "cancellationToken");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Call_InRecordWithPositionalToken_ShouldReportDiagnostic()
+    {
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+public record Service(CancellationToken Token)
+{
+    public Task RunAsync() => Task.{|#0:Delay|}(100);
+}
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}";
+
+        var expected = VerifyCS.Diagnostic("CC002")
+            .WithLocation(0)
+            .WithArguments("Delay", "Token");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Call_InStaticMethodOfPrimaryConstructorClass_ShouldNotReportDiagnostic()
+    {
+        // A static member cannot capture primary-constructor parameters (CS9105-adjacent), so
+        // suggesting the token would produce non-compiling code.
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Worker(CancellationToken cancellationToken)
+{
+    public static Task RunAsync() => Task.Delay(100);
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Call_InNonPrimaryConstructorOfPrimaryConstructorClass_ShouldNotReportDiagnostic()
+    {
+        // A non-primary constructor's body cannot reference primary-constructor parameters
+        // (CS9105); only its own parameter list counts.
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Worker(CancellationToken cancellationToken)
+{
+    private readonly Task _unused = Task.CompletedTask;
+
+    public Worker() : this(CancellationToken.None)
+    {
+        Task.Delay(100);
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Call_InStaticFieldInitializer_ShouldNotReportDiagnostic()
+    {
+        // Static initializers run without instance context; the primary-constructor token is
+        // not available there.
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Worker(CancellationToken cancellationToken)
+{
+    private static readonly Task _init = Task.Delay(100);
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
 }

--- a/tests/CancelCop.Analyzer.Tests/TokenPropagationAnalyzerTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/TokenPropagationAnalyzerTests.cs
@@ -564,6 +564,47 @@ public class Worker(CancellationToken cancellationToken)
     }
 
     [Fact]
+    public async Task Call_InStaticEventFieldInitializerLambda_ShouldNotReportDiagnostic()
+    {
+        // A static event-field initializer runs without instance context, so the
+        // primary-constructor token is unavailable (CS9105) — same rule as static fields.
+        var test = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Worker(CancellationToken cancellationToken)
+{
+    private static event Func<Task> Initialized = async () => await Task.Delay(100);
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Call_InPartialTypePart_WithPrimaryConstructorOnOtherPart_ShouldReportDiagnostic()
+    {
+        // The primary constructor lives on the other partial part; capture from this part is
+        // still legal, so the token must be found through the type symbol.
+        var test = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+public partial class Worker(CancellationToken cancellationToken);
+
+public partial class Worker
+{
+    public Task RunAsync() => Task.{|#0:Delay|}(100);
+}";
+
+        var expected = VerifyCS.Diagnostic("CC002")
+            .WithLocation(0)
+            .WithArguments("Delay", "cancellationToken");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
     public async Task Call_InStaticFieldInitializer_ShouldNotReportDiagnostic()
     {
         // Static initializers run without instance context; the primary-constructor token is


### PR DESCRIPTION
## Summary

Loop 5 of the analyzer-health hardening loop — closes the P1 backlog item from `docs/ANALYZER_HEALTH.md`.

- The shared `FindEnclosingCancellationTokenParameter` walk now finds tokens declared on **constructors** and **C# 12 primary constructors** (classes and records), closing the false-negative class where CC002/CC003/CC004/CC009 stayed silent despite an in-scope token.
- Constructors end the search at their own parameter list (a non-primary constructor body cannot reference primary-constructor parameters — CS9105).
- Tokenless non-static methods and instance field initializers fall through to the containing type''s primary-constructor parameters; the first containing type always ends the search.
- Conservative guards: static members, static field initializers, and operators never see the primary-constructor token (capture is illegal there).

## Tests

- 10 new tests: 7 CC002 (constructor, primary-ctor method, field initializer, positional record, plus static-method/static-initializer/non-primary-ctor negatives), 1 CC003 constructor, 1 CC004 primary constructor, 1 CC009 primary constructor.
- Full suite: **194 passed, 0 failed** (184 prior + 10 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)