### PR TITLE
test: rule-catalog trust drift guards (README + release tracking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.8] - 2026-06-09
+
+### Added
+
+- **Rule-catalog trust contract** (`RuleCatalogTests`): drift-guard tests asserting that every
+  descriptor a shipped analyzer registers has a README rule-table row with the correct severity
+  and fix mark, is tracked in `AnalyzerReleases.Shipped.md` with the correct severity, and that
+  every exported code-fix provider targets a shipped rule. A rule can no longer be added, renamed,
+  or re-severitied without the public docs following.
+
 ## [1.4.7] - 2026-06-09
 
 ### Changed

--- a/docs/ANALYZER_HEALTH.md
+++ b/docs/ANALYZER_HEALTH.md
@@ -1,6 +1,6 @@
 # Analyzer Health
 
-Reviewed: 2026-06-09 (refreshed through the v1.4.7 hardening loop)
+Reviewed: 2026-06-09 (refreshed through the v1.4.8 hardening loop)
 
 A deliberately harsh health audit for the nine implemented CancelCop rule IDs (CC001–CC006, CC009).
 Scores are 1–5, where `5` means reference-quality and hard to improve, `3` means usable but
@@ -113,9 +113,11 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
   MediatR interface; switch its inline token check to `CancellationTokenHelpers`.
 - **Analyzer XML docs.** CC003, CC004, CC005A, CC005B lack the `<remarks>`/`<example>` doc blocks that
   CC001/CC002/CC009 carry.
-- **Rule-catalog trust contract.** There is no test asserting every shipped analyzer's descriptor is
-  documented in README + `AnalyzerReleases.Shipped.md` (AutoMapper's `RuleCatalogTests` is the model).
-  A drift guard would catch undocumented or renamed rules.
+- ~~**Rule-catalog trust contract** (v1.4.8).~~ `RuleCatalogTests` now asserts every shipped
+  descriptor has a README rule-table row (severity + fix mark accurate), is tracked in
+  `AnalyzerReleases.Shipped.md` with matching severity, and that every exported code-fix provider
+  targets a shipped rule — plus a discovery canary so reflection finding zero analyzers cannot
+  vacuously pass.
 
 ## Cross-Cutting Findings
 
@@ -132,6 +134,7 @@ Grading: **P0** = release-blocking; **P1** = next hardening loop; **P2** = oppor
 
 ## Verification Baseline
 
+- v1.4.8: 205 tests (200 + 5 `RuleCatalogTests` drift guards), verified via CI (`build-and-test`).
 - v1.4.7: 200 tests, pure refactor verified via CI (`build-and-test`).
 - v1.4.6: 200 tests (196 after v1.4.5 + 4 named-argument fixer tests incl. the overload-name
   trap case) — verified via CI (`build-and-test`) because local test execution is currently

--- a/src/CancelCop.Analyzer.Package/CancelCop.Analyzer.Package.csproj
+++ b/src/CancelCop.Analyzer.Package/CancelCop.Analyzer.Package.csproj
@@ -13,7 +13,7 @@
         <PackageId>CancelCop.Analyzer</PackageId>
         <!-- Fallback for local packs; the publish workflow overrides this with -p:Version from
              the release tag so the published package always matches the tag. -->
-        <Version>1.4.7</Version>
+        <Version>1.4.8</Version>
         <Authors>George Wall</Authors>
         <Description>A surgical Roslyn analyzer focused on CancellationToken best practices: propagation, parameter positioning, loop cancellation checks, and more. Includes automatic code fixes for public APIs, handlers, EF Core, HTTP calls, and Minimal APIs.</Description>
         <PackageTags>roslyn;analyzer;cancellationtoken;async;code-fix;loops;efcore;httpclient</PackageTags>

--- a/tests/CancelCop.Analyzer.Tests/RuleCatalogTests.cs
+++ b/tests/CancelCop.Analyzer.Tests/RuleCatalogTests.cs
@@ -1,0 +1,159 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace CancelCop.Analyzer.Tests;
+
+/// <summary>
+/// Trust drift guards: every descriptor a shipped analyzer registers must be documented in the
+/// README rule table (with the correct severity and fix mark) and tracked in
+/// AnalyzerReleases.Shipped.md. These tests fail when a rule is added, renamed, or re-severitied
+/// without the public docs following.
+/// </summary>
+public class RuleCatalogTests
+{
+    private static readonly Assembly AnalyzerAssembly = typeof(MissingCancellationTokenAnalyzer).Assembly;
+    private static readonly Assembly CodeFixAssembly = typeof(MissingCancellationTokenCodeFixProvider).Assembly;
+
+    private static ImmutableArray<DiagnosticDescriptor> GetShippedDescriptors() =>
+        AnalyzerAssembly.GetTypes()
+            .Where(t => !t.IsAbstract && typeof(DiagnosticAnalyzer).IsAssignableFrom(t))
+            .Select(t => (DiagnosticAnalyzer)Activator.CreateInstance(t)!)
+            .SelectMany(a => a.SupportedDiagnostics)
+            .ToImmutableArray();
+
+    private static ImmutableHashSet<string> GetFixableDiagnosticIds() =>
+        CodeFixAssembly.GetTypes()
+            .Where(t => !t.IsAbstract && typeof(CodeFixProvider).IsAssignableFrom(t))
+            .Select(t => (CodeFixProvider)Activator.CreateInstance(t)!)
+            .SelectMany(p => p.FixableDiagnosticIds)
+            .ToImmutableHashSet();
+
+    private static string GetRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "CancelCop.sln")))
+            directory = directory.Parent;
+
+        Assert.NotNull(directory);
+        return directory!.FullName;
+    }
+
+    /// <summary>README rule-table rows: | **CC001** | title | Warning | ✅ |</summary>
+    private static Dictionary<string, (string Severity, string FixMark)> GetReadmeRuleRows()
+    {
+        var readme = File.ReadAllText(Path.Combine(GetRepoRoot(), "README.md"));
+        var rows = new Dictionary<string, (string, string)>();
+
+        foreach (Match match in Regex.Matches(
+                     readme,
+                     @"^\|\s*\*\*(CC\w+)\*\*\s*\|[^|]*\|\s*(\w+)\s*\|\s*(✅|❌)\s*\|",
+                     RegexOptions.Multiline))
+        {
+            rows[match.Groups[1].Value] = (match.Groups[2].Value, match.Groups[3].Value);
+        }
+
+        return rows;
+    }
+
+    private static Dictionary<string, string> GetShippedReleaseRows()
+    {
+        var shipped = File.ReadAllText(Path.Combine(
+            GetRepoRoot(), "src", "CancelCop.Analyzer", "AnalyzerReleases.Shipped.md"));
+        var rows = new Dictionary<string, string>();
+
+        foreach (Match match in Regex.Matches(
+                     shipped,
+                     @"^(CC\w+)\s*\|\s*\w+\s*\|\s*(\w+)\s*\|",
+                     RegexOptions.Multiline))
+        {
+            rows[match.Groups[1].Value] = match.Groups[2].Value;
+        }
+
+        return rows;
+    }
+
+    [Fact]
+    public void ShippedAnalyzers_ExposeAtLeastTheNineKnownRules()
+    {
+        var ids = GetShippedDescriptors().Select(d => d.Id).ToImmutableHashSet();
+
+        // Canary: if reflection-based discovery silently finds nothing, every other guard here
+        // would vacuously pass.
+        Assert.Superset(
+            new HashSet<string> { "CC001", "CC002", "CC003", "CC004", "CC005A", "CC005B", "CC005C", "CC006", "CC009" },
+            ids.ToHashSet());
+    }
+
+    [Fact]
+    public void EveryShippedRule_HasAReadmeRuleTableRow_WithMatchingSeverity()
+    {
+        var rows = GetReadmeRuleRows();
+
+        foreach (var descriptor in GetShippedDescriptors())
+        {
+            Assert.True(
+                rows.ContainsKey(descriptor.Id),
+                $"{descriptor.Id} is registered by an analyzer but has no row in the README rule table.");
+
+            Assert.True(
+                rows[descriptor.Id].Severity == descriptor.DefaultSeverity.ToString(),
+                $"{descriptor.Id}: README severity '{rows[descriptor.Id].Severity}' does not match " +
+                $"the shipped descriptor severity '{descriptor.DefaultSeverity}'.");
+        }
+    }
+
+    [Fact]
+    public void EveryShippedRule_IsTrackedInAnalyzerReleasesShipped_WithMatchingSeverity()
+    {
+        var rows = GetShippedReleaseRows();
+
+        foreach (var descriptor in GetShippedDescriptors())
+        {
+            Assert.True(
+                rows.ContainsKey(descriptor.Id),
+                $"{descriptor.Id} is registered by an analyzer but is missing from AnalyzerReleases.Shipped.md.");
+
+            Assert.True(
+                rows[descriptor.Id] == descriptor.DefaultSeverity.ToString(),
+                $"{descriptor.Id}: AnalyzerReleases.Shipped.md severity '{rows[descriptor.Id]}' does not " +
+                $"match the shipped descriptor severity '{descriptor.DefaultSeverity}'.");
+        }
+    }
+
+    [Fact]
+    public void ReadmeFixColumn_MatchesExportedCodeFixProviders()
+    {
+        var fixableIds = GetFixableDiagnosticIds();
+        var rows = GetReadmeRuleRows();
+
+        foreach (var descriptor in GetShippedDescriptors())
+        {
+            if (!rows.TryGetValue(descriptor.Id, out var row))
+                continue; // the README-presence test reports this case
+
+            var expected = fixableIds.Contains(descriptor.Id) ? "✅" : "❌";
+            Assert.True(
+                row.FixMark == expected,
+                $"{descriptor.Id}: README fix column shows '{row.FixMark}' but the code-fix " +
+                $"assembly {(expected == "✅" ? "exports" : "does not export")} a provider for it.");
+        }
+    }
+
+    [Fact]
+    public void EveryExportedCodeFixProvider_TargetsAShippedRule()
+    {
+        var shippedIds = GetShippedDescriptors().Select(d => d.Id).ToImmutableHashSet();
+
+        foreach (var fixableId in GetFixableDiagnosticIds())
+        {
+            Assert.True(
+                shippedIds.Contains(fixableId),
+                $"A code-fix provider targets '{fixableId}', which no shipped analyzer registers.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Loop 8 of the analyzer-health hardening loop — closes the `RuleCatalogTests` trust-contract backlog item (the AutoMapper audit''s model).

New `RuleCatalogTests` (5 tests, pure reflection + doc parsing):
- Every descriptor registered by a shipped analyzer has a **README rule-table row** with the descriptor''s severity and an accurate ✅/❌ fix mark.
- Every descriptor is tracked in **`AnalyzerReleases.Shipped.md`** with matching severity.
- Every exported **code-fix provider targets a shipped rule**.
- A discovery **canary** pins the nine known rule IDs so reflection finding zero analyzers cannot vacuously pass.

Regexes validated against the current README/Shipped.md content (all 9 rules parse, severities and fix marks match).

## Verification

- CI `build-and-test` (local `dotnet test` remains blocked by Smart App Control — see `docs/ANALYZER_HEALTH.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)